### PR TITLE
Add an environment variable for the directory of failed image diffs

### DIFF
--- a/FBTestSnapshotController.m
+++ b/FBTestSnapshotController.m
@@ -255,7 +255,11 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
   NSString *fileName = [self _fileNameForSelector:selector
                                        identifier:identifier
                                      fileNameType:fileNameType];
-  NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:NSStringFromClass(_testClass)];
+  NSString *folderPath = NSTemporaryDirectory();
+  if (getenv("IMAGE_DIFF_DIR")) {
+    folderPath = @(getenv("IMAGE_DIFF_DIR"));
+  }
+  NSString *filePath = [folderPath stringByAppendingPathComponent:NSStringFromClass(_testClass)];
   filePath = [filePath stringByAppendingPathComponent:fileName];
   return filePath;
 }


### PR DESCRIPTION
This commit adds an environment variable `IMAGE_DIFF_DIR` which defines the base directory for failed images.

With this you can integrate this great tool in an CI environment and save the images as artifacts.
