### PR TITLE
Save diff image if test failed

### DIFF
--- a/FBTestSnapshotController.m
+++ b/FBTestSnapshotController.m
@@ -322,7 +322,7 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
     return nil;
   }
   CGSize imageSize = CGSizeMake(MAX(image.size.width, renderedImage.size.width), MAX(image.size.height, renderedImage.size.height));
-  UIGraphicsBeginImageContextWithOptions(imageSize, YES, [[UIScreen mainScreen] scale]);
+  UIGraphicsBeginImageContextWithOptions(imageSize, YES, 0.0);
   CGContextRef context = UIGraphicsGetCurrentContext();
   [image drawInRect:CGRectMake(0, 0, image.size.width, image.size.height)];
   CGContextSetAlpha(context, 0.5f);


### PR DESCRIPTION
Save a diff image if a view test failed.
With this you can directly see the difference without using a third party image diff tool.
