### PR TITLE
Refactored parts of FBSnapshotTestCase into FBSnapshotTestRecorder.

### DIFF
--- a/FBSnapshotTestCase.h
+++ b/FBSnapshotTestCase.h
@@ -30,7 +30,7 @@
 { \
   NSError *error__ = nil; \
   NSString *referenceImagesDirectory__ = [NSString stringWithFormat:@"%s", FB_REFERENCE_IMAGE_DIR]; \
-  BOOL comparisonSuccess__ = [self compareSnapshotOfView:(view__) referenceImagesDirectory:referenceImagesDirectory__ identifier:(identifier__) error:&error__]; \
+  BOOL comparisonSuccess__ = [self compareSnapshotOfView:(view__) referenceImagesDirectory:referenceImagesDirectory__ identifier:(identifier__) error:&error__ testSelector:[self selector] recordMode:[self recordMode]]; \
   XCTAssertTrue(comparisonSuccess__, @"Snapshot comparison failed: %@", error__); \
 }
 
@@ -43,7 +43,7 @@
 { \
   NSError *error__ = nil; \
   NSString *referenceImagesDirectory__ = [NSString stringWithFormat:@"%s", FB_REFERENCE_IMAGE_DIR]; \
-  BOOL comparisonSuccess__ = [self compareSnapshotOfLayer:(layer__) referenceImagesDirectory:referenceImagesDirectory__ identifier:(identifier__) error:&error__]; \
+  BOOL comparisonSuccess__ = [self compareSnapshotOfLayer:(layer__) referenceImagesDirectory:referenceImagesDirectory__ identifier:(identifier__) error:&error__ testSelector:[self selector] recordMode:[self recordMode]]; \
   XCTAssertTrue(comparisonSuccess__, @"Snapshot comparison failed: %@", error__); \
 }
 
@@ -64,29 +64,36 @@
 @property (readwrite, nonatomic, assign) BOOL recordMode;
 
 /**
- Performs the comparisong or records a snapshot of the layer if recordMode is YES.
+ Performs the comparison or records a snapshot of the layer.
  @param layer The Layer to snapshot
  @param referenceImagesDirectory The directory in which reference images are stored.
  @param identifier An optional identifier, used is there are muliptle snapshot tests in a given -test method.
  @param error An error to log in an XCTAssert() macro if the method fails (missing reference image, images differ, etc).
+ @param selector Test selector.
+ @param record Record a snapshot of the view if YES.
  @returns YES if the comparison (or saving of the reference image) succeeded.
  */
 - (BOOL)compareSnapshotOfLayer:(CALayer *)layer
       referenceImagesDirectory:(NSString *)referenceImagesDirectory
                     identifier:(NSString *)identifier
-                         error:(NSError **)errorPtr;
+                         error:(NSError **)errorPtr
+                  testSelector:(SEL)selector
+                    recordMode:(BOOL)record;
 
 /**
- Performs the comparisong or records a snapshot of the view if recordMode is YES.
+ Performs the comparison or records a snapshot of the view.
  @param view The view to snapshot
  @param referenceImagesDirectory The directory in which reference images are stored.
  @param identifier An optional identifier, used is there are muliptle snapshot tests in a given -test method.
  @param error An error to log in an XCTAssert() macro if the method fails (missing reference image, images differ, etc).
+ @param selector Test selector.
+ @param record Record a snapshot of the view if YES.
  @returns YES if the comparison (or saving of the reference image) succeeded.
  */
 - (BOOL)compareSnapshotOfView:(UIView *)view
      referenceImagesDirectory:(NSString *)referenceImagesDirectory
                    identifier:(NSString *)identifier
-                        error:(NSError **)errorPtr;
-
+                        error:(NSError **)errorPtr
+                 testSelector:(SEL)selector
+                   recordMode:(BOOL)record;
 @end

--- a/FBSnapshotTestCase.m
+++ b/FBSnapshotTestCase.m
@@ -11,10 +11,12 @@
 #import "FBSnapshotTestCase.h"
 
 #import "FBTestSnapshotController.h"
+#import "FBSnapshotTestRecorder.h"
 
 @interface FBSnapshotTestCase ()
 
 @property (readwrite, nonatomic, retain) FBTestSnapshotController *snapshotController;
+@property (readwrite, nonatomic, retain) FBSnapshotTestRecorder *recorder;
 
 @end
 
@@ -24,11 +26,13 @@
 {
   [super setUp];
   self.snapshotController = [[FBTestSnapshotController alloc] initWithTestClass:[self class]];
+  self.recorder = [[FBSnapshotTestRecorder alloc] initWithController:_snapshotController];
 }
 
 - (void)tearDown
 {
   self.snapshotController = nil;
+  self.recorder = nil;
   [super tearDown];
 }
 
@@ -36,103 +40,30 @@
       referenceImagesDirectory:(NSString *)referenceImagesDirectory
                     identifier:(NSString *)identifier
                          error:(NSError **)errorPtr
+                  testSelector:(SEL)selector
+                    recordMode:(BOOL)record
 {
-  return [self _compareSnapshotOfViewOrLayer:layer
-                    referenceImagesDirectory:referenceImagesDirectory
-                                  identifier:identifier
-                                       error:errorPtr];
+    _recorder.selector = selector;
+    _recorder.recordMode = record;
+    return [_recorder compareSnapshotOfViewOrLayer:layer
+                          referenceImagesDirectory:referenceImagesDirectory
+                                        identifier:identifier
+                                             error:errorPtr];
 }
 
 - (BOOL)compareSnapshotOfView:(UIView *)view
      referenceImagesDirectory:(NSString *)referenceImagesDirectory
                    identifier:(NSString *)identifier
                         error:(NSError **)errorPtr
+                 testSelector:(SEL)selector
+                   recordMode:(BOOL)record
 {
-  return [self _compareSnapshotOfViewOrLayer:view
-                    referenceImagesDirectory:referenceImagesDirectory
-                                  identifier:identifier
-                                       error:errorPtr];
-}
-
-#pragma mark -
-#pragma mark Private API
-
-- (BOOL)_compareSnapshotOfViewOrLayer:(id)viewOrLayer
-             referenceImagesDirectory:(NSString *)referenceImagesDirectory
-                           identifier:(NSString *)identifier
-                                error:(NSError **)errorPtr
-{
-  _snapshotController.referenceImagesDirectory = referenceImagesDirectory;
-  if (self.recordMode) {
-    return [self _recordSnapshotOfViewOrLayer:viewOrLayer identifier:identifier error:errorPtr];
-  } else {
-    return [self _performPixelComparisonWithViewOrLayer:viewOrLayer identifier:identifier error:errorPtr];
-  }
-}
-
-- (BOOL)_performPixelComparisonWithViewOrLayer:(UIView *)viewOrLayer
-                                    identifier:(NSString *)identifier
-                                         error:(NSError **)errorPtr
-{
-  UIImage *referenceImage = [_snapshotController referenceImageForSelector:self.selector identifier:identifier error:errorPtr];
-  if (nil != referenceImage) {
-    UIImage *snapshot = [self _snapshotViewOrLayer:viewOrLayer];
-    BOOL imagesSame = [_snapshotController compareReferenceImage:referenceImage toImage:snapshot error:errorPtr];
-    if (!imagesSame) {
-      [_snapshotController saveFailedReferenceImage:referenceImage
-                                          testImage:snapshot
-                                           selector:self.selector
-                                         identifier:identifier
-                                              error:errorPtr];
-    }
-    return imagesSame;
-  }
-  return NO;
-}
-
-- (BOOL)_recordSnapshotOfViewOrLayer:(id)viewOrLayer
-                          identifier:(NSString *)identifier
-                               error:(NSError **)errorPtr
-{
-  UIImage *snapshot = [self _snapshotViewOrLayer:viewOrLayer];
-  return [_snapshotController saveReferenceImage:snapshot selector:self.selector identifier:identifier error:errorPtr];
-}
-
-- (UIImage *)_snapshotViewOrLayer:(id)viewOrLayer
-{
-  CALayer *layer = nil;
-
-  if ([viewOrLayer isKindOfClass:[UIView class]]) {
-    UIView *view = (UIView *)viewOrLayer;
-    [view layoutIfNeeded];
-    layer = view.layer;
-  } else if ([viewOrLayer isKindOfClass:[CALayer class]]) {
-    layer = (CALayer *)viewOrLayer;
-    [layer layoutIfNeeded];
-  } else {
-    XCTAssertTrue(NO, @"Only UIView and CALayer classes can be snapshotted!  %@", viewOrLayer);
-  }
-
-  return [self _renderLayer:layer];
-}
-
-- (UIImage *)_renderLayer:(CALayer *)layer
-{
-  CGRect bounds = layer.bounds;
-
-  UIGraphicsBeginImageContextWithOptions(bounds.size, NO, 0);
-  CGContextRef context = UIGraphicsGetCurrentContext();
-
-  CGContextSaveGState(context);
-  {
-    [layer renderInContext:context];
-  }
-  CGContextRestoreGState(context);
-
-  UIImage *snapshot = UIGraphicsGetImageFromCurrentImageContext();
-  UIGraphicsEndImageContext();
-
-  return snapshot;
+    _recorder.selector = selector;
+    _recorder.recordMode = record;
+    return [_recorder compareSnapshotOfViewOrLayer:view
+                          referenceImagesDirectory:referenceImagesDirectory
+                                        identifier:identifier
+                                             error:errorPtr];
 }
 
 @end

--- a/FBSnapshotTestCase.podspec
+++ b/FBSnapshotTestCase.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
                     two images don't match.
                    DESC
   s.homepage     = "https://github.com/facebook/ios-snapshot-test-case"
-  
+
   s.license      = 'BSD'
   s.author       = 'Facebook'
   s.source       = { :git => "https://github.com/facebook/ios-snapshot-test-case.git",
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.framework    = 'XCTest'
 
-  s.source_files = 'FBSnapshotTestCase.{h,m}', 'FBTestSnapshotController.{h,m}'
+  s.source_files = 'FBSnapshotTestCase.{h,m}', 'FBTestSnapshotController.{h,m}', 'FBSnapshotTestRecorder.{h,m}'
 
   fb_def = 'FB_REFERENCE_IMAGE_DIR'
   fb_val = '"$(SOURCE_ROOT)/$(PROJECT_NAME)Tests/ReferenceImages"'

--- a/FBSnapshotTestCaseDemo/FBSnapshotTestCaseDemo.xcodeproj/project.pbxproj
+++ b/FBSnapshotTestCaseDemo/FBSnapshotTestCaseDemo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3C20E1DE188579B800BDDDD6 /* FBSnapshotTestRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C20E1DD188579B800BDDDD6 /* FBSnapshotTestRecorder.m */; };
 		A24E010717F9A42A001252DB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A24E010617F9A42A001252DB /* Foundation.framework */; };
 		A24E010917F9A42A001252DB /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A24E010817F9A42A001252DB /* CoreGraphics.framework */; };
 		A24E010B17F9A42A001252DB /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A24E010A17F9A42A001252DB /* UIKit.framework */; };
@@ -35,6 +36,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3C20E1DC188579B800BDDDD6 /* FBSnapshotTestRecorder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FBSnapshotTestRecorder.h; path = ../FBSnapshotTestRecorder.h; sourceTree = "<group>"; };
+		3C20E1DD188579B800BDDDD6 /* FBSnapshotTestRecorder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FBSnapshotTestRecorder.m; path = ../FBSnapshotTestRecorder.m; sourceTree = "<group>"; };
 		A23E9CB517FA9C300071B3CE /* FBSnapshotTestCaseDemo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = FBSnapshotTestCaseDemo.xcconfig; path = ../FBSnapshotTestCaseDemo.xcconfig; sourceTree = "<group>"; };
 		A24E010317F9A42A001252DB /* FBSnapshotTestCaseDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FBSnapshotTestCaseDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A24E010617F9A42A001252DB /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -165,6 +168,8 @@
 				A24E013717F9A445001252DB /* FBSnapshotTestCase.m */,
 				A24E013817F9A445001252DB /* FBTestSnapshotController.h */,
 				A24E013917F9A445001252DB /* FBTestSnapshotController.m */,
+				3C20E1DC188579B800BDDDD6 /* FBSnapshotTestRecorder.h */,
+				3C20E1DD188579B800BDDDD6 /* FBSnapshotTestRecorder.m */,
 			);
 			name = FBSnapshotTestCase;
 			sourceTree = "<group>";
@@ -266,6 +271,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A257F0C917FA982900AB1B02 /* FBExampleView.m in Sources */,
+				3C20E1DE188579B800BDDDD6 /* FBSnapshotTestRecorder.m in Sources */,
 				A24E011717F9A42A001252DB /* FBAppDelegate.m in Sources */,
 				A24E011317F9A42A001252DB /* main.m in Sources */,
 			);

--- a/FBSnapshotTestRecorder.h
+++ b/FBSnapshotTestRecorder.h
@@ -1,0 +1,37 @@
+//
+//  FBSnapshotTestRecorder.h
+//  FBSnapshotTestCaseDemo
+//
+//  Created by Daniel Doubrovkine on 1/14/14.
+//  Copyright (c) 2014 Facebook. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#include "FBTestSnapshotController.h"
+
+@interface FBSnapshotTestRecorder : NSObject
+
+@property (readwrite, nonatomic, assign) BOOL recordMode;
+@property (readwrite, nonatomic, assign) SEL selector;
+@property (readwrite, nonatomic, retain) FBTestSnapshotController *snapshotController;
+
+- (id)initWithController:(FBTestSnapshotController *)controller;
+
+- (BOOL)compareSnapshotOfViewOrLayer:(id)viewOrLayer
+            referenceImagesDirectory:(NSString *)referenceImagesDirectory
+                          identifier:(NSString *)identifier
+                               error:(NSError **)errorPtr;
+
+- (BOOL)performPixelComparisonWithViewOrLayer:(UIView *)viewOrLayer
+                                   identifier:(NSString *)identifier
+                                        error:(NSError **)errorPtr;
+
+- (BOOL)recordSnapshotOfViewOrLayer:(id)viewOrLayer
+                          identifier:(NSString *)identifier
+                               error:(NSError **)errorPtr;
+
+- (UIImage *)snapshotViewOrLayer:(id)viewOrLayer;
+
+- (UIImage *)renderLayer:(CALayer *)layer;
+
+@end

--- a/FBSnapshotTestRecorder.m
+++ b/FBSnapshotTestRecorder.m
@@ -1,0 +1,100 @@
+//
+//  FBSnapshotTestRecorder.m
+//  FBSnapshotTestCaseDemo
+//
+//  Created by Daniel Doubrovkine on 1/14/14.
+//  Copyright (c) 2014 Facebook. All rights reserved.
+//
+
+#import "FBSnapshotTestRecorder.h"
+
+@implementation FBSnapshotTestRecorder
+
+- (id) initWithController:(FBTestSnapshotController *)controller
+{
+    if (self = [super init]) {
+        self.snapshotController = controller;
+        self.recordMode = NO;
+    }
+    return self;
+}
+
+- (BOOL)compareSnapshotOfViewOrLayer:(id)viewOrLayer
+            referenceImagesDirectory:(NSString *)referenceImagesDirectory
+                          identifier:(NSString *)identifier
+                               error:(NSError **)errorPtr
+{
+    _snapshotController.referenceImagesDirectory = referenceImagesDirectory;
+    if (self.recordMode) {
+        return [self recordSnapshotOfViewOrLayer:viewOrLayer identifier:identifier error:errorPtr];
+    } else {
+        return [self performPixelComparisonWithViewOrLayer:viewOrLayer identifier:identifier error:errorPtr];
+    }
+}
+
+- (BOOL)performPixelComparisonWithViewOrLayer:(UIView *)viewOrLayer
+                                    identifier:(NSString *)identifier
+                                         error:(NSError **)errorPtr
+{
+    UIImage *referenceImage = [_snapshotController referenceImageForSelector:self.selector identifier:identifier error:errorPtr];
+    if (nil != referenceImage) {
+        UIImage *snapshot = [self snapshotViewOrLayer:viewOrLayer];
+        BOOL imagesSame = [_snapshotController compareReferenceImage:referenceImage toImage:snapshot error:errorPtr];
+        if (!imagesSame) {
+            [_snapshotController saveFailedReferenceImage:referenceImage
+                                                testImage:snapshot
+                                                 selector:self.selector
+                                               identifier:identifier
+                                                    error:errorPtr];
+        }
+        return imagesSame;
+    }
+    return NO;
+}
+
+- (BOOL)recordSnapshotOfViewOrLayer:(id)viewOrLayer
+                          identifier:(NSString *)identifier
+                               error:(NSError **)errorPtr
+{
+    UIImage *snapshot = [self snapshotViewOrLayer:viewOrLayer];
+    return [_snapshotController saveReferenceImage:snapshot selector:self.selector identifier:identifier error:errorPtr];
+}
+
+- (UIImage *)snapshotViewOrLayer:(id)viewOrLayer
+{
+    CALayer *layer = nil;
+    
+    if ([viewOrLayer isKindOfClass:[UIView class]]) {
+        UIView *view = (UIView *)viewOrLayer;
+        [view layoutIfNeeded];
+        layer = view.layer;
+    } else if ([viewOrLayer isKindOfClass:[CALayer class]]) {
+        layer = (CALayer *)viewOrLayer;
+        [layer layoutIfNeeded];
+    } else {
+        [NSException raise:@"Invalid view or layer" format:@"Only UIView and CALayer classes can be snapshotted!  %@", viewOrLayer];
+    }
+    
+    return [self renderLayer:layer];
+}
+
+- (UIImage *)renderLayer:(CALayer *)layer
+{
+    CGRect bounds = layer.bounds;
+    
+    UIGraphicsBeginImageContextWithOptions(bounds.size, NO, 0);
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    
+    CGContextSaveGState(context);
+    {
+        [layer renderInContext:context];
+    }
+    CGContextRestoreGState(context);
+    
+    UIImage *snapshot = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    
+    return snapshot;
+}
+
+@end


### PR DESCRIPTION
Related to https://github.com/facebook/ios-snapshot-test-case/issues/7, this just pulls out private functionality of `FBSnapshotTestCase` into `FBSnapshotTestRecorder`. Note that we now have to pass in `recordMode` and `selector` into this at test runtime.

With this change we can write a Specta test. See https://github.com/dblock/ios-snapshot-test-case-expecta for the implementation.

PS: I have signed the FB CLA.
