### PR TITLE
Renamed all instances of FBTestSnapshot to FBSnapshotTest.

### DIFF
--- a/FBSnapshotTestCase.m
+++ b/FBSnapshotTestCase.m
@@ -10,11 +10,11 @@
 
 #import "FBSnapshotTestCase.h"
 
-#import "FBTestSnapshotController.h"
+#import "FBSnapshotTestController.h"
 
 @interface FBSnapshotTestCase ()
 
-@property (readwrite, nonatomic, retain) FBTestSnapshotController *snapshotController;
+@property (readwrite, nonatomic, retain) FBSnapshotTestController *snapshotController;
 
 @end
 
@@ -23,7 +23,7 @@
 - (void)setUp
 {
   [super setUp];
-  self.snapshotController = [[FBTestSnapshotController alloc] initWithTestClass:[self class]];
+  self.snapshotController = [[FBSnapshotTestController alloc] initWithTestClass:[self class]];
 }
 
 - (void)tearDown

--- a/FBSnapshotTestCase.podspec
+++ b/FBSnapshotTestCase.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
                     two images don't match.
                    DESC
   s.homepage     = "https://github.com/facebook/ios-snapshot-test-case"
-  
+
   s.license      = 'BSD'
   s.author       = 'Facebook'
   s.source       = { :git => "https://github.com/facebook/ios-snapshot-test-case.git",
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.framework    = 'XCTest'
 
-  s.source_files = 'FBSnapshotTestCase.{h,m}', 'FBTestSnapshotController.{h,m}', 'UIImage+*{h,m}'
+  s.source_files = 'FBSnapshotTestCase.{h,m}', 'FBSnapshotTestController.{h,m}', 'UIImage+*{h,m}'
 
   fb_def = 'FB_REFERENCE_IMAGE_DIR'
   fb_val = '"$(SOURCE_ROOT)/$(PROJECT_NAME)Tests/ReferenceImages"'

--- a/FBSnapshotTestCase.xcworkspace/contents.xcworkspacedata
+++ b/FBSnapshotTestCase.xcworkspace/contents.xcworkspacedata
@@ -11,10 +11,10 @@
          location = "group:FBSnapshotTestCase.m">
       </FileRef>
       <FileRef
-         location = "group:FBTestSnapshotController.h">
+         location = "group:/Users/dblock/source/ios-snapshot-test-case/dblock/FBSnapshotTestController.h">
       </FileRef>
       <FileRef
-         location = "group:FBTestSnapshotController.m">
+         location = "group:/Users/dblock/source/ios-snapshot-test-case/dblock/FBSnapshotTestController.m">
       </FileRef>
    </Group>
    <FileRef

--- a/FBSnapshotTestCaseDemo/FBSnapshotTestCaseDemo.xcodeproj/project.pbxproj
+++ b/FBSnapshotTestCaseDemo/FBSnapshotTestCaseDemo.xcodeproj/project.pbxproj
@@ -21,7 +21,7 @@
 		A24E012A17F9A42A001252DB /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = A24E012817F9A42A001252DB /* InfoPlist.strings */; };
 		A24E012C17F9A42A001252DB /* FBSnapshotTestCaseDemoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A24E012B17F9A42A001252DB /* FBSnapshotTestCaseDemoTests.m */; };
 		A24E013A17F9A445001252DB /* FBSnapshotTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = A24E013717F9A445001252DB /* FBSnapshotTestCase.m */; };
-		A24E013B17F9A445001252DB /* FBTestSnapshotController.m in Sources */ = {isa = PBXBuildFile; fileRef = A24E013917F9A445001252DB /* FBTestSnapshotController.m */; };
+		A24E013B17F9A445001252DB /* FBSnapshotTestController.m in Sources */ = {isa = PBXBuildFile; fileRef = A24E013917F9A445001252DB /* FBSnapshotTestController.m */; };
 		A257F0C917FA982900AB1B02 /* FBExampleView.m in Sources */ = {isa = PBXBuildFile; fileRef = A257F0C817FA982800AB1B02 /* FBExampleView.m */; };
 		FD93077618B345AA003B7EF6 /* UIImage+Compare.m in Sources */ = {isa = PBXBuildFile; fileRef = FD93077518B345AA003B7EF6 /* UIImage+Compare.m */; };
 /* End PBXBuildFile section */
@@ -58,8 +58,8 @@
 		A24E012B17F9A42A001252DB /* FBSnapshotTestCaseDemoTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBSnapshotTestCaseDemoTests.m; sourceTree = "<group>"; };
 		A24E013617F9A445001252DB /* FBSnapshotTestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FBSnapshotTestCase.h; path = ../FBSnapshotTestCase.h; sourceTree = "<group>"; };
 		A24E013717F9A445001252DB /* FBSnapshotTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FBSnapshotTestCase.m; path = ../FBSnapshotTestCase.m; sourceTree = "<group>"; };
-		A24E013817F9A445001252DB /* FBTestSnapshotController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FBTestSnapshotController.h; path = ../FBTestSnapshotController.h; sourceTree = "<group>"; };
-		A24E013917F9A445001252DB /* FBTestSnapshotController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FBTestSnapshotController.m; path = ../FBTestSnapshotController.m; sourceTree = "<group>"; };
+		A24E013817F9A445001252DB /* FBSnapshotTestController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FBSnapshotTestController.h; path = ../FBSnapshotTestController.h; sourceTree = "<group>"; };
+		A24E013917F9A445001252DB /* FBSnapshotTestController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FBSnapshotTestController.m; path = ../FBSnapshotTestController.m; sourceTree = "<group>"; };
 		A257F0C717FA982800AB1B02 /* FBExampleView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBExampleView.h; sourceTree = "<group>"; };
 		A257F0C817FA982800AB1B02 /* FBExampleView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBExampleView.m; sourceTree = "<group>"; };
 		FD93077418B345AA003B7EF6 /* UIImage+Compare.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIImage+Compare.h"; path = "../UIImage+Compare.h"; sourceTree = "<group>"; };
@@ -169,8 +169,8 @@
 			children = (
 				A24E013617F9A445001252DB /* FBSnapshotTestCase.h */,
 				A24E013717F9A445001252DB /* FBSnapshotTestCase.m */,
-				A24E013817F9A445001252DB /* FBTestSnapshotController.h */,
-				A24E013917F9A445001252DB /* FBTestSnapshotController.m */,
+				A24E013817F9A445001252DB /* FBSnapshotTestController.h */,
+				A24E013917F9A445001252DB /* FBSnapshotTestController.m */,
 				53455EA718B3355D00571FEA /* UIImage+Diff.h */,
 				53455EA818B3355D00571FEA /* UIImage+Diff.m */,
 				FD93077418B345AA003B7EF6 /* UIImage+Compare.h */,
@@ -285,7 +285,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A24E013B17F9A445001252DB /* FBTestSnapshotController.m in Sources */,
+				A24E013B17F9A445001252DB /* FBSnapshotTestController.m in Sources */,
 				A24E012C17F9A42A001252DB /* FBSnapshotTestCaseDemoTests.m in Sources */,
 				53455EA918B3355D00571FEA /* UIImage+Diff.m in Sources */,
 				A24E013A17F9A445001252DB /* FBSnapshotTestCase.m in Sources */,

--- a/FBSnapshotTestController.h
+++ b/FBSnapshotTestController.h
@@ -11,20 +11,20 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-typedef NS_ENUM(NSInteger, FBTestSnapshotControllerErrorCode) {
-  FBTestSnapshotControllerErrorCodeUnknown,
-  FBTestSnapshotControllerErrorCodeNeedsRecord,
-  FBTestSnapshotControllerErrorCodePNGCreationFailed,
-  FBTestSnapshotControllerErrorCodeImagesDifferentSizes,
-  FBTestSnapshotControllerErrorCodeImagesDifferent,
+typedef NS_ENUM(NSInteger, FBSnapshotTestControllerErrorCode) {
+  FBSnapshotTestControllerErrorCodeUnknown,
+  FBSnapshotTestControllerErrorCodeNeedsRecord,
+  FBSnapshotTestControllerErrorCodePNGCreationFailed,
+  FBSnapshotTestControllerErrorCodeImagesDifferentSizes,
+  FBSnapshotTestControllerErrorCodeImagesDifferent,
 };
 /**
- Errors returned by the methods of FBTestSnapshotController use this domain.
+ Errors returned by the methods of FBSnapshotTestController use this domain.
  */
-extern NSString *const FBTestSnapshotControllerErrorDomain;
+extern NSString *const FBSnapshotTestControllerErrorDomain;
 
 /**
- Errors returned by the methods of FBTestSnapshotController sometimes contain this key in the `userInfo` dictionary.
+ Errors returned by the methods of FBSnapshotTestController sometimes contain this key in the `userInfo` dictionary.
  */
 extern NSString *const FBReferenceImageFilePathKey;
 
@@ -33,7 +33,7 @@ extern NSString *const FBReferenceImageFilePathKey;
  by-pixel comparison of images.
  Instances are initialized with the test class, and directories to read and write to.
  */
-@interface FBTestSnapshotController : NSObject
+@interface FBSnapshotTestController : NSObject
 
 /**
  Record snapshots.
@@ -46,7 +46,7 @@ extern NSString *const FBReferenceImageFilePathKey;
  for those tests.
  @param testClass The subclass of FBSnapshotTestCase that is using this controller.
  @param referenceImagesDirectory The directory where the reference images are stored.
- @returns An instance of FBTestSnapshotController.
+ @returns An instance of FBSnapshotTestController.
  */
 - (id)initWithTestClass:(Class)testClass;
 

--- a/FBSnapshotTestController.m
+++ b/FBSnapshotTestController.m
@@ -8,7 +8,7 @@
  *
  */
 
-#import "FBTestSnapshotController.h"
+#import "FBSnapshotTestController.h"
 
 #import "UIImage+Compare.h"
 #import "UIImage+Diff.h"
@@ -17,7 +17,7 @@
 
 #import <UIKit/UIKit.h>
 
-NSString *const FBTestSnapshotControllerErrorDomain = @"FBTestSnapshotControllerErrorDomain";
+NSString *const FBSnapshotTestControllerErrorDomain = @"FBSnapshotTestControllerErrorDomain";
 
 NSString *const FBReferenceImageFilePathKey = @"FBReferenceImageFilePathKey";
 
@@ -28,13 +28,13 @@ typedef struct RGBAPixel {
   char a;
 } RGBAPixel;
 
-@interface FBTestSnapshotController ()
+@interface FBSnapshotTestController ()
 
 @property (readonly, nonatomic, retain) Class testClass;
 
 @end
 
-@implementation FBTestSnapshotController
+@implementation FBSnapshotTestController
 {
   NSFileManager *_fileManager;
 }
@@ -71,16 +71,16 @@ typedef struct RGBAPixel {
   if (nil == image && NULL != errorPtr) {
     BOOL exists = [_fileManager fileExistsAtPath:filePath];
     if (!exists) {
-      *errorPtr = [NSError errorWithDomain:FBTestSnapshotControllerErrorDomain
-                                      code:FBTestSnapshotControllerErrorCodeNeedsRecord
+      *errorPtr = [NSError errorWithDomain:FBSnapshotTestControllerErrorDomain
+                                      code:FBSnapshotTestControllerErrorCodeNeedsRecord
                                   userInfo:@{
                FBReferenceImageFilePathKey: filePath,
                  NSLocalizedDescriptionKey: @"Unable to load reference image.",
           NSLocalizedFailureReasonErrorKey: @"Reference image not found. You need to run the test in record mode",
                    }];
     } else {
-      *errorPtr = [NSError errorWithDomain:FBTestSnapshotControllerErrorDomain
-                                      code:FBTestSnapshotControllerErrorCodeUnknown
+      *errorPtr = [NSError errorWithDomain:FBSnapshotTestControllerErrorDomain
+                                      code:FBSnapshotTestControllerErrorCodeUnknown
                                   userInfo:nil];
     }
   }
@@ -111,8 +111,8 @@ typedef struct RGBAPixel {
       didWrite = [pngData writeToFile:filePath options:NSDataWritingAtomic error:errorPtr];
     } else {
       if (nil != errorPtr) {
-        *errorPtr = [NSError errorWithDomain:FBTestSnapshotControllerErrorDomain
-                                        code:FBTestSnapshotControllerErrorCodePNGCreationFailed
+        *errorPtr = [NSError errorWithDomain:FBSnapshotTestControllerErrorDomain
+                                        code:FBSnapshotTestControllerErrorCodePNGCreationFailed
                                     userInfo:@{
                  FBReferenceImageFilePathKey: filePath,
                      }];
@@ -182,8 +182,8 @@ typedef struct RGBAPixel {
 
     BOOL imagesEqual = [referenceImage compareWithImage:image];
     if (NULL != errorPtr) {
-      *errorPtr = [NSError errorWithDomain:FBTestSnapshotControllerErrorDomain
-                                      code:FBTestSnapshotControllerErrorCodeImagesDifferent
+      *errorPtr = [NSError errorWithDomain:FBSnapshotTestControllerErrorDomain
+                                      code:FBSnapshotTestControllerErrorCodeImagesDifferent
                                   userInfo:@{
                  NSLocalizedDescriptionKey: @"Images different",
                    }];
@@ -191,8 +191,8 @@ typedef struct RGBAPixel {
     return imagesEqual;
   }
   if (NULL != errorPtr) {
-    *errorPtr = [NSError errorWithDomain:FBTestSnapshotControllerErrorDomain
-                                    code:FBTestSnapshotControllerErrorCodeImagesDifferentSizes
+    *errorPtr = [NSError errorWithDomain:FBSnapshotTestControllerErrorDomain
+                                    code:FBSnapshotTestControllerErrorCodeImagesDifferentSizes
                                 userInfo:@{
                NSLocalizedDescriptionKey: @"Images different sizes",
         NSLocalizedFailureReasonErrorKey: [NSString stringWithFormat:@"referenceImage:%@, image:%@",

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ We developed `FBSnapshotTestCase` to make snapshot tests easy.
 Creating a snapshot test
 ------------------------
 
-1. Drop the `FBSnapshotTestCase` and `FBTestSnapshotController` source files
+1. Drop the `FBSnapshotTestCase` and `FBSnapshotTestController` source files
    into your project. In the Add Files dialog, be sure to check the **tests**
    target, not the main target.
 

--- a/Tests/FBSnapshotControllerTests.m
+++ b/Tests/FBSnapshotControllerTests.m
@@ -9,7 +9,7 @@
  */
 
 #import <XCTest/XCTest.h>
-#import "FBTestSnapshotController.h"
+#import "FBSnapshotTestController.h"
 
 @interface FBSnapshotControllerTests : XCTestCase
 
@@ -31,7 +31,7 @@
     XCTAssertNotNil(referenceImage, @"");
     UIImage *testImage = [self bundledImageNamed:@"square-copy" type:@"png"];
     XCTAssertNotNil(testImage, @"");
-    FBTestSnapshotController *controller = [[FBTestSnapshotController alloc] initWithTestClass:nil];
+    FBSnapshotTestController *controller = [[FBSnapshotTestController alloc] initWithTestClass:nil];
     XCTAssertTrue([controller compareReferenceImage:referenceImage toImage:testImage error:nil], @"");
 }
 
@@ -41,7 +41,7 @@
     XCTAssertNotNil(referenceImage, @"");
     UIImage *testImage = [self bundledImageNamed:@"square_with_text" type:@"png"];
     XCTAssertNotNil(testImage, @"");
-    FBTestSnapshotController *controller = [[FBTestSnapshotController alloc] initWithTestClass:nil];
+    FBSnapshotTestController *controller = [[FBSnapshotTestController alloc] initWithTestClass:nil];
     XCTAssertFalse([controller compareReferenceImage:referenceImage toImage:testImage error:nil], @"");
 }
 

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		B3090DC518AED83A00516CAD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3090DC418AED83A00516CAD /* Foundation.framework */; };
 		B3090DC718AED83A00516CAD /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3090DC618AED83A00516CAD /* UIKit.framework */; };
 		B3090DD518AED8D200516CAD /* FBSnapshotControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B3090DD418AED8D200516CAD /* FBSnapshotControllerTests.m */; };
-		B3090DD918AED95300516CAD /* FBTestSnapshotController.m in Sources */ = {isa = PBXBuildFile; fileRef = B3090DD818AED95300516CAD /* FBTestSnapshotController.m */; };
+		B3090DD918AED95300516CAD /* FBSnapshotTestController.m in Sources */ = {isa = PBXBuildFile; fileRef = B3090DD818AED95300516CAD /* FBSnapshotTestController.m */; };
 		B3090DDD18AEDAD000516CAD /* square_with_text.png in Resources */ = {isa = PBXBuildFile; fileRef = B3090DDA18AEDAD000516CAD /* square_with_text.png */; };
 		B3090DDE18AEDAD000516CAD /* square-copy.png in Resources */ = {isa = PBXBuildFile; fileRef = B3090DDB18AEDAD000516CAD /* square-copy.png */; };
 		B3090DDF18AEDAD000516CAD /* square.png in Resources */ = {isa = PBXBuildFile; fileRef = B3090DDC18AEDAD000516CAD /* square.png */; };
@@ -25,8 +25,8 @@
 		B3090DC418AED83A00516CAD /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		B3090DC618AED83A00516CAD /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		B3090DD418AED8D200516CAD /* FBSnapshotControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSnapshotControllerTests.m; sourceTree = SOURCE_ROOT; };
-		B3090DD718AED95300516CAD /* FBTestSnapshotController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FBTestSnapshotController.h; path = ../FBTestSnapshotController.h; sourceTree = "<group>"; };
-		B3090DD818AED95300516CAD /* FBTestSnapshotController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FBTestSnapshotController.m; path = ../FBTestSnapshotController.m; sourceTree = "<group>"; };
+		B3090DD718AED95300516CAD /* FBSnapshotTestController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FBSnapshotTestController.h; path = ../FBSnapshotTestController.h; sourceTree = "<group>"; };
+		B3090DD818AED95300516CAD /* FBSnapshotTestController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FBSnapshotTestController.m; path = ../FBSnapshotTestController.m; sourceTree = "<group>"; };
 		B3090DDA18AEDAD000516CAD /* square_with_text.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = square_with_text.png; sourceTree = SOURCE_ROOT; };
 		B3090DDB18AEDAD000516CAD /* square-copy.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "square-copy.png"; sourceTree = SOURCE_ROOT; };
 		B3090DDC18AEDAD000516CAD /* square.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = square.png; sourceTree = SOURCE_ROOT; };
@@ -92,8 +92,8 @@
 		B3090DD618AED8E600516CAD /* FBSnapshotTestCase */ = {
 			isa = PBXGroup;
 			children = (
-				B3090DD718AED95300516CAD /* FBTestSnapshotController.h */,
-				B3090DD818AED95300516CAD /* FBTestSnapshotController.m */,
+				B3090DD718AED95300516CAD /* FBSnapshotTestController.h */,
+				B3090DD818AED95300516CAD /* FBSnapshotTestController.m */,
 				B3107CDF18B3985000FAFCBE /* UIImage+Compare.h */,
 				B3107CE018B3985000FAFCBE /* UIImage+Compare.m */,
 			);
@@ -165,7 +165,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B3090DD518AED8D200516CAD /* FBSnapshotControllerTests.m in Sources */,
-				B3090DD918AED95300516CAD /* FBTestSnapshotController.m in Sources */,
+				B3090DD918AED95300516CAD /* FBSnapshotTestController.m in Sources */,
 				B3107CE118B3985000FAFCBE /* UIImage+Compare.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
More consistent class naming, no public interface changes.

You could argue the opposite and say that `FBTestSnapshot` represents a "test snapshot", but it just looks weird IMO :) And the README says that we're talking about a "snapshot test case".

This is on top of #13. Closes #9.
