### PR TITLE
Add Xcode Template file for FBSnapshotTests

### DIFF
--- a/SnapshotTest.xctemplate/TemplateInfo.plist
+++ b/SnapshotTest.xctemplate/TemplateInfo.plist
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AllowedTypes</key>
+	<array>
+		<string>public.objective-c-source</string>
+	</array>
+	<key>Platforms</key>
+	<array>
+		<string>com.apple.platform.iphoneos</string>
+	</array>
+	<key>DefaultCompletionName</key>
+	<string>SnapshotTest</string>
+	<key>Description</key>
+	<string>Test case using FBSnapshotTests</string>
+	<key>Kind</key>
+	<string>Xcode.IDEKit.TextSubstitutionFileTemplateKind</string>
+	<key>MainTemplateFile</key>
+	<string>___FILEBASENAME___.m</string>
+	<key>SortOrder</key>
+	<integer>1</integer>
+	<key>Summary</key>
+	<string>FBSnapshotTests</string>
+	<key>Options</key>
+	<array>
+		<dict>
+			<key>Default</key>
+			<string></string>
+			<key>Description</key>
+			<string>Class Under Test</string>
+			<key>Identifier</key>
+			<string>cutClass</string>
+			<key>Name</key>
+			<string>Test case for class name</string>
+			<key>Required</key>
+			<true/>
+			<key>NotPersisted</key>
+			<true/>
+			<key>Type</key>
+			<string>text</string>
+		</dict>
+		<dict>
+			<key>Default</key>
+			<string></string>
+			<key>Description</key>
+			<string>Property Name</string>
+			<key>Identifier</key>
+			<string>propName</string>
+			<key>Name</key>
+			<string>Property Name</string>
+			<key>Required</key>
+			<true/>
+			<key>NotPersisted</key>
+			<true/>
+			<key>Type</key>
+			<string>text</string>
+		</dict>
+		<dict>
+			<key>Default</key>
+			<string>___VARIABLE_cutClass:identifier___SnapshotTests</string>
+			<key>Identifier</key>
+			<string>productName</string>
+			<key>Type</key>
+			<string>static</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/SnapshotTest.xctemplate/___FILEBASENAME___.m
+++ b/SnapshotTest.xctemplate/___FILEBASENAME___.m
@@ -1,0 +1,40 @@
+//
+//  ___FILENAME___
+//  ___PROJECTNAME___
+//
+//  Created by ___FULLUSERNAME___ on ___DATE___.
+//  Copyright ___YEAR___ ___ORGANIZATIONNAME___. All rights reserved.
+//
+
+#import "___VARIABLE_cutClass:identifier___.h"
+#import "FBSnapshotTestCase.h"
+
+@interface ___VARIABLE_cutClass:identifier___SnapshotTests : FBSnapshotTestCase
+@property (nonatomic, strong) ___VARIABLE_cutClass:identifier___ *___VARIABLE_propName:identifier___;
+@end
+
+@implementation ___VARIABLE_cutClass:identifier___SnapshotTests
+
+- (void)setUp
+{
+    [super setUp];
+
+    self.recordMode = YES;
+
+    self.___VARIABLE_propName:identifier___ = [[___VARIABLE_cutClass:identifier___ alloc] init];
+}
+
+- (void)tearDown
+{
+    self.___VARIABLE_propName:identifier___ = nil;
+    [super tearDown];
+}
+
+- (void)test<#testnamehere#>
+{
+    <# set up your view and add the data #>
+
+    FBSnapshotVerifyView(self.___VARIABLE_propName:identifier___, nil);
+}
+
+@end


### PR DESCRIPTION
Because of the frequency of snapshot tests that we write, we've created an Xcode template file to help. 

This is a simpler version of ours that I thought people might be interested in so I'm sharing it.

I've added it to the root of the repo. To use it you have to copy the structure into your personal Xcode templates folder.

eg: `~/Library/Developer/Xcode/Templates/File Templates/<custom-folder-name>`

After you restart Xcode it will show up in the Xcode New File menu. I've added a couple quick inputs where you can type in the view under test and what you want the property to be called in the test.
![screen shot 2014-03-20 at 8 55 41 pm](https://f.cloud.github.com/assets/1066132/2479260/b0c3fd0a-b093-11e3-92ea-61aba317f1a1.png)

That will result in a test file that looks like:
![screen shot 2014-03-20 at 8 55 51 pm](https://f.cloud.github.com/assets/1066132/2479261/bc206878-b093-11e3-8c54-0e63f31dd2fe.png)

Just thought I'd share. Happy coding!
