### PR TITLE
Assertion for UIGraphicsBeginImageContextWithOptions NULL return value

### DIFF
--- a/FBSnapshotTestController.m
+++ b/FBSnapshotTestController.m
@@ -355,11 +355,14 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
 - (UIImage *)_renderLayer:(CALayer *)layer
 {
   CGRect bounds = layer.bounds;
-  
+
+  NSAssert1(CGRectGetWidth(bounds), @"Zero width for layer %@", layer);
+  NSAssert1(CGRectGetHeight(bounds), @"Zero height for layer %@", layer);
+
   UIGraphicsBeginImageContextWithOptions(bounds.size, NO, 0);
   CGContextRef context = UIGraphicsGetCurrentContext();
   NSAssert1(context, @"Could not generate context for layer %@", layer);
-
+  
   CGContextSaveGState(context);
   {
     [layer renderInContext:context];


### PR DESCRIPTION
Hi guys,

First of all, LOVE this tool; my whole UI development approach has changed since I started using it. Great work!

Just a tiny one here: had a minor issue earlier whereby reference images weren't being generated for a spec. Was confused as to why, until I discovered that an Autolayout error was causing my view to have zero height. This emits the usually `CGContextRef` errors:

```
 <Error>: CGContextSaveGState: invalid context 0x0. This is a serious error. This application, or a library it uses, is using an invalid context  and is thereby contributing to an overall degradation of system stability and reliability. This notice is a courtesy: please fix this problem. It will become a fatal error in an upcoming update.
```

I noticed there's nothing in the code to prevent this from happening, so seems like an assertion here would save users some debugging time. You could, of course, do more specific assertions based on the layer's width/height, and other possible failure cases. At the very least this covers all eventualities.

Thanks!

J
