### PR TITLE
Xcode 6 / iOS 8 needs a scaleFactor

### DIFF
--- a/UIImage+Compare.m
+++ b/UIImage+Compare.m
@@ -65,6 +65,10 @@
                                                     (CGBitmapInfo)kCGImageAlphaPremultipliedLast
                                                     );
     
+  CGFloat scaleFactor = [[UIScreen mainScreen] scale];
+  CGContextScaleCTM(referenceImageContext, scaleFactor, scaleFactor);
+  CGContextScaleCTM(imageContext, scaleFactor, scaleFactor);
+    
   if (!referenceImageContext || !imageContext) {
     CGContextRelease(referenceImageContext);
     CGContextRelease(imageContext);


### PR DESCRIPTION
iOS 8 needs a scaleFactor if you create a `CGBitmapContextCreate`

Fixes #48 
