### PR TITLE
Remove renderAsLayer setting (will now always render as layer)

### DIFF
--- a/FBSnapshotTestCase/FBSnapshotTestCase.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.h
@@ -61,11 +61,6 @@
 @property (readwrite, nonatomic, assign) BOOL recordMode;
 
 /**
- When YES, the test will render a view as layer.
- **/
-@property (readwrite, nonatomic, assign) BOOL renderAsLayer;
-
-/**
  Performs the comparisong or records a snapshot of the layer if recordMode is YES.
  @param layer The Layer to snapshot
  @param referenceImagesDirectory The directory in which reference images are stored.

--- a/FBSnapshotTestCase/FBSnapshotTestCase.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.m
@@ -42,16 +42,6 @@
   self.snapshotController.recordMode = recordMode;
 }
 
-- (BOOL)renderAsLayer
-{
-    return self.snapshotController.renderAsLayer;
-}
-
-- (void)setRenderAsLayer:(BOOL)renderAsLayer
-{
-    self.snapshotController.renderAsLayer = renderAsLayer;
-}
-
 - (BOOL)compareSnapshotOfLayer:(CALayer *)layer
       referenceImagesDirectory:(NSString *)referenceImagesDirectory
                     identifier:(NSString *)identifier

--- a/FBSnapshotTestCase/FBSnapshotTestController.h
+++ b/FBSnapshotTestCase/FBSnapshotTestController.h
@@ -41,11 +41,6 @@ extern NSString *const FBReferenceImageFilePathKey;
 @property(readwrite, nonatomic, assign) BOOL recordMode;
 
 /**
- Render as layer (NO) or with drawViewHierarchyInRect on iOS 7+ (YES)
- **/
-@property(readwrite, nonatomic, assign) BOOL renderAsLayer;
-
-/**
  @param testClass The subclass of FBSnapshotTestCase that is using this controller.
  @param referenceImagesDirectory The directory where the reference images are stored.
  @returns An instance of FBSnapshotTestController.

--- a/FBSnapshotTestCase/FBSnapshotTestController.m
+++ b/FBSnapshotTestCase/FBSnapshotTestController.m
@@ -385,19 +385,6 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
         
 - (UIImage *)_renderView:(UIView *)view
 {
-  if (!self.renderAsLayer) {
-#ifdef __IPHONE_7_0
-    if ([view respondsToSelector:@selector(drawViewHierarchyInRect:afterScreenUpdates:)]) {
-      UIGraphicsBeginImageContextWithOptions(view.frame.size, NO, 0);
-      [view drawViewHierarchyInRect:view.bounds afterScreenUpdates:YES];
-      UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-      UIGraphicsEndImageContext();
-      return image;
-    }
-#else
-    NSLog(@"drawViewHierarchy is only available on iOS 7+");
-#endif
-  }
   [view layoutIfNeeded];
   return [self _renderLayer:view.layer];
 }


### PR DESCRIPTION
The drawViewHierarchyInRect:afterScreenUpdates: approach to rendering was added in #19 as a more 'accurate' rendering mechanism, but time has shown that's not the case (#47). There's no need to support two rendering methods, so this pull request drops the drawViewHierarchyInRect:afterScreenUpdates: approach in favor of layer rendering.

This is an API breaking change, as the renderAsLayer method has been removed from FBSnapshotTestCase. Here are the steps to reconcile:

* if you set renderAsLayer = YES, simply remove all calls to renderAsLayer (renderAsLayer = YES is now the sole rendering behavior)
* if you set renderAsLayer = NO or don't set it at all, then you will need remove any calls and re-record snapshots with the latest version of FBSnapshotTestCase since the rendering method has changed
