### PR TITLE
Allow tests to specify a suffix for the snapshot reference directory

### DIFF
--- a/FBSnapshotTestCase/FBSnapshotTestCase.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.h
@@ -22,28 +22,38 @@
  Similar to our much-loved XCTAssert() macros. Use this to perform your test. No need to write an explanation, though.
  @param view The view to snapshot
  @param identifier An optional identifier, used if there are multiple snapshot tests in a given -test method.
+ @param referenceImageDirectorySuffix An optional suffix, appended to the reference image directory path, such as "_iOS8"
  */
+#define FBSnapshotVerifyViewWithReferenceDirectorySuffix(view__, identifier__, referenceImagesDirectorySuffix__) \
+{ \
+NSError *error__ = nil; \
+NSString *referenceImagesDirectory__ = [NSString stringWithFormat:@"%s%@", FB_REFERENCE_IMAGE_DIR, referenceImagesDirectorySuffix__]; \
+BOOL comparisonSuccess__ = [self compareSnapshotOfView:(view__) referenceImagesDirectory:referenceImagesDirectory__ identifier:(identifier__) error:&error__]; \
+XCTAssertTrue(comparisonSuccess__, @"Snapshot comparison failed: %@", error__); \
+}
+
 #define FBSnapshotVerifyView(view__, identifier__) \
 { \
-  NSError *error__ = nil; \
-  NSString *referenceImagesDirectory__ = [NSString stringWithFormat:@"%s", FB_REFERENCE_IMAGE_DIR]; \
-  BOOL comparisonSuccess__ = [self compareSnapshotOfView:(view__) referenceImagesDirectory:referenceImagesDirectory__ identifier:(identifier__) error:&error__]; \
-  XCTAssertTrue(comparisonSuccess__, @"Snapshot comparison failed: %@", error__); \
-  XCTAssertFalse(self.recordMode, @"Test ran in record mode. Reference image is now saved. Disable record mode to perform an actual snapshot comparison!"); \
+FBSnapshotVerifyViewWithReferenceDirectorySuffix(view__, identifier__, @""); \
 }
 
 /**
  Similar to our much-loved XCTAssert() macros. Use this to perform your test. No need to write an explanation, though.
  @param layer The layer to snapshot
- @param identifier An optional identifier, used if there are multiple snapshot tests in a given -test method.
+ @param identifier An optional identifier, used is there are multiple snapshot tests in a given -test method.
+ @param referenceImageDirectorySuffix An optional suffix, appended to the reference image directory path, such as "_iOS8"
  */
+#define FBSnapshotVerifyLayerWithReferenceDirectorySuffix(layer__, identifier__, referenceImagesDirectorySuffix__) \
+{ \
+NSError *error__ = nil; \
+NSString *referenceImagesDirectory__ = [NSString stringWithFormat:@"%s%@", FB_REFERENCE_IMAGE_DIR, referenceImagesDirectorySuffix__]; \
+BOOL comparisonSuccess__ = [self compareSnapshotOfLayer:(layer__) referenceImagesDirectory:referenceImagesDirectory__ identifier:(identifier__) error:&error__]; \
+XCTAssertTrue(comparisonSuccess__, @"Snapshot comparison failed: %@", error__); \
+}
+
 #define FBSnapshotVerifyLayer(layer__, identifier__) \
 { \
-  NSError *error__ = nil; \
-  NSString *referenceImagesDirectory__ = [NSString stringWithFormat:@"%s", FB_REFERENCE_IMAGE_DIR]; \
-  BOOL comparisonSuccess__ = [self compareSnapshotOfLayer:(layer__) referenceImagesDirectory:referenceImagesDirectory__ identifier:(identifier__) error:&error__]; \
-  XCTAssertTrue(comparisonSuccess__, @"Snapshot comparison failed: %@", error__); \
-  XCTAssertFalse(self.recordMode, @"Test ran in record mode. Reference image is now saved. Disable record mode to perform an actual snapshot comparison!"); \
+FBSnapshotVerifyLayerWithReferenceDirectorySuffix(layer__, identifier__, @""); \
 }
 
 /**


### PR DESCRIPTION
Tests can now compute and specify a reference directory suffix based on any criteria (iOS version, architecture) in order to store separate sets of reference images.