### PR TITLE
Added assertion on setRecordMode

### DIFF
--- a/FBSnapshotTestCase/FBSnapshotTestCase.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.m
@@ -36,6 +36,7 @@
 
 - (void)setRecordMode:(BOOL)recordMode
 {
+  NSAssert1(_snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
   _snapshotController.recordMode = recordMode;
 }
 


### PR DESCRIPTION
In my experience it's very easy to do the following
```
- (void)setUp
{
  self.recordMode = YES;
  [super setUp];
}
```

This assertion will save some time when trying to figure out why `self.recordMode = YES;` has no effect.