### PR TITLE
Build on Xcode 6.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: objective-c
-
+osx_image: beta-xcode6.3
 script:
   ./build.sh

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,7 @@ set -eu
 function ci_lib() {
     xcodebuild -project FBSnapshotTestCase.xcodeproj \
                -scheme FBSnapshotTestCase \
+               -destination "platform=iOS Simulator,name=iPhone 6" \
                -sdk iphonesimulator \
                build test
 }


### PR DESCRIPTION
I have seen some build errors with Travis and Circle CI on Xcode 6.3.1.

Error: `clang: error: invalid architecture 'arm' for deployment target '-mios-simulator-version-min=8.3'`

This is to experiment.