### PR TITLE
Allow usage of objective-c subspec only for projects supporting iOS 7

### DIFF
--- a/FBSnapshotTestCase.podspec
+++ b/FBSnapshotTestCase.podspec
@@ -19,5 +19,12 @@ Pod::Spec.new do |s|
   s.framework    = 'XCTest'
   s.public_header_files = ['FBSnapshotTestCase/FBSnapshotTestCase.h', 'FBSnapshotTestCase/FBSnapshotTestCasePlatform.h']
   s.private_header_files = ['FBSnapshotTestCase/FBSnapshotTestController.h', 'FBSnapshotTestCase/UIImage+Compare.h', 'FBSnapshotTestCase/UIImage+Diff.h']
-  s.source_files = 'FBSnapshotTestCase/**/*.{h,m,swift}'
+  s.default_subspecs = 'SwiftSupport'
+  s.subspec 'Core' do |cs|
+    cs.source_files = 'FBSnapshotTestCase/**/*.{h,m}'
+  end
+  s.subspec 'SwiftSupport' do |cs|
+    cs.dependency 'FBSnapshotTestCase/Core'
+    cs.source_files = 'FBSnapshotTestCase/**/*.swift'
+  end
 end

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Installation with CocoaPods
      end
      ```
 
+   If you support iOS 7 use `FBSnapshotTestCase/Core` instead, which doesn't contain Swift support.
+
    Replace "Tests" with the name of your test project.
 
 2. Define `FB_REFERENCE_IMAGE_DIR` in your scheme. This should


### PR DESCRIPTION
You can use Swift in CocoaPods only on > iOS 7 projects, so i made a subspec `Core` which only contains the Objective-C files.