### PR TITLE
Reference image directory support for Swift

### DIFF
--- a/FBSnapshotTestCase/SwiftSupport.swift
+++ b/FBSnapshotTestCase/SwiftSupport.swift
@@ -10,34 +10,28 @@
 
 public extension FBSnapshotTestCase {
   public func FBSnapshotVerifyView(view: UIView, identifier: String = "", suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), file: String = __FILE__, line: UInt = __LINE__) {
-    let envReferenceImageDirectory = NSProcessInfo.processInfo().environment["FB_REFERENCE_IMAGE_DIR"] as? String
-    var error: NSError?
-
-    if let envReferenceImageDirectory = envReferenceImageDirectory {
-      for suffix in suffixes {
-        let referenceImagesDirectory = "\(envReferenceImageDirectory)\(suffix)"
-        let comparisonSuccess = compareSnapshotOfView(view, referenceImagesDirectory: referenceImagesDirectory, identifier: identifier, tolerance: 0, error: &error)
-        if comparisonSuccess || recordMode {
-          break
-        }
-
-        assert(comparisonSuccess, message: "Snapshot comparison failed: \(error)", file: file, line: line)
-        assert(recordMode == false, message: "Test ran in record mode. Reference image is now saved. Disable record mode to perform an actual snapshot comparison!", file: file, line: line)
-      }
-    } else {
-      assert(false, message: "Missing value for referenceImagesDirectory - Set FB_REFERENCE_IMAGE_DIR as Environment variable in your scheme.", file: file, line: line)
-    }
+    FBSnapshotVerifyViewOrLayer(view, identifier: identifier, suffixes: suffixes)
   }
 
   public func FBSnapshotVerifyLayer(layer: CALayer, identifier: String = "", suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), file: String = __FILE__, line: UInt = __LINE__) {
-    let envReferenceImageDirectory = NSProcessInfo.processInfo().environment["FB_REFERENCE_IMAGE_DIR"] as? String
+    FBSnapshotVerifyViewOrLayer(layer, identifier: identifier, suffixes: suffixes)
+  }
+
+  private func FBSnapshotVerifyViewOrLayer(viewOrLayer: AnyObject, identifier: String = "", suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), file: String = __FILE__, line: UInt = __LINE__) {
+    let envReferenceImageDirectory = self.getReferenceImageDirectoryWithDefault(FB_REFERENCE_IMAGE_DIR)
     var error: NSError?
     var comparisonSuccess = false
 
     if let envReferenceImageDirectory = envReferenceImageDirectory {
       for suffix in suffixes {
         let referenceImagesDirectory = "\(envReferenceImageDirectory)\(suffix)"
-        comparisonSuccess = compareSnapshotOfLayer(layer, referenceImagesDirectory: referenceImagesDirectory, identifier: identifier, tolerance: 0, error: &error)
+        if viewOrLayer.isKindOfClass(UIView) {
+          comparisonSuccess = compareSnapshotOfView(viewOrLayer as! UIView, referenceImagesDirectory: referenceImagesDirectory, identifier: identifier, tolerance: 0, error: &error)
+        } else if viewOrLayer.isKindOfClass(CALayer) {
+            comparisonSuccess = compareSnapshotOfLayer(viewOrLayer as! CALayer, referenceImagesDirectory: referenceImagesDirectory, identifier: identifier, tolerance: 0, error: &error)
+        } else {
+          assertionFailure("Only UIView and CALayer classes can be snapshotted")
+        }
         if comparisonSuccess || recordMode {
           break
         }

--- a/FBSnapshotTestCaseDemo/FBSnapshotTestCaseDemo.xcodeproj/project.pbxproj
+++ b/FBSnapshotTestCaseDemo/FBSnapshotTestCaseDemo.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		B30449221AB794320067C75D /* FBSnapshotTestCaseDemoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B30449211AB794320067C75D /* FBSnapshotTestCaseDemoTests.m */; };
 		B30449351AB795230067C75D /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = B304492C1AB795230067C75D /* InfoPlist.strings */; };
 		B30449361AB795230067C75D /* FBAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = B304492F1AB795230067C75D /* FBAppDelegate.m */; };
-		B30449381AB795230067C75D /* FBSnapshotTestCaseDemo-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = B30449321AB795230067C75D /* FBSnapshotTestCaseDemo-Info.plist */; };
 		B30449391AB795230067C75D /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B30449341AB795230067C75D /* Images.xcassets */; };
 		F02D88451B1F246300BFBC1D /* FBSnapshotTestCaseSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F02D88441B1F246300BFBC1D /* FBSnapshotTestCaseSwiftTests.swift */; };
 /* End PBXBuildFile section */
@@ -198,7 +197,7 @@
 		B30448FA1AB794320067C75D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0610;
+				LastUpgradeCheck = 0640;
 				ORGANIZATIONNAME = Facebook;
 				TargetAttributes = {
 					B30449011AB794320067C75D = {
@@ -236,7 +235,6 @@
 			files = (
 				B30449391AB795230067C75D /* Images.xcassets in Resources */,
 				B30449351AB795230067C75D /* InfoPlist.strings in Resources */,
-				B30449381AB795230067C75D /* FBSnapshotTestCaseDemo-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FBSnapshotTestCaseDemo/FBSnapshotTestCaseDemo.xcodeproj/xcshareddata/xcschemes/FBSnapshotTestCaseDemo.xcscheme
+++ b/FBSnapshotTestCaseDemo/FBSnapshotTestCaseDemo.xcodeproj/xcshareddata/xcschemes/FBSnapshotTestCaseDemo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0640"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
1. #104 added support for references images that are part of the bundle so I am support the same feature is Swift
2. Added a private function `FBSnapshotVerifyViewOrLayer`
3. Fixed a couple Xcode warnings