### PR TITLE
Fixing tolerance issues with retina images

### DIFF
--- a/FBSnapshotTestCase/Categories/UIImage+Compare.m
+++ b/FBSnapshotTestCase/Categories/UIImage+Compare.m
@@ -101,7 +101,7 @@ typedef union {
     imageEqual = (memcmp(referenceImagePixels, imagePixels, referenceImageSizeBytes) == 0);
   } else {
     // Go through each pixel in turn and see if it is different
-    const NSInteger pixelCount = self.size.width * self.size.height;
+    const NSInteger pixelCount = referenceImageSize.width * referenceImageSize.height;
 
     FBComparePixel *p1 = referenceImagePixels;
     FBComparePixel *p2 = imagePixels;

--- a/FBSnapshotTestCaseDemo/Podfile.lock
+++ b/FBSnapshotTestCaseDemo/Podfile.lock
@@ -10,9 +10,9 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   FBSnapshotTestCase:
-    :path: ..
+    :path: ".."
 
 SPEC CHECKSUMS:
   FBSnapshotTestCase: bfa674b5a5a0a79559c1544e3d2846927d6b6d2a
 
-COCOAPODS: 0.38.0
+COCOAPODS: 0.38.2


### PR DESCRIPTION
the `.size` property of the `UIImage` returns the size measured in points