### PR TITLE
Adds ability to use device model and OS on image names

### DIFF
--- a/FBSnapshotTestCase/FBSnapshotTestCase.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.h
@@ -103,6 +103,12 @@
 @property (readwrite, nonatomic, assign) BOOL recordMode;
 
 /**
+ When @c YES appends the name of the device model and OS to the snapshot file name.
+ The default value is @c NO.
+ */
+@property (readwrite, nonatomic, assign, getter=isDeviceAgnostic) BOOL deviceAgnostic;
+
+/**
  When YES, renders a snapshot of the complete view hierarchy as visible onscreen.
  There are several things that do not work if renderInContext: is used.
  - UIVisualEffect #70

--- a/FBSnapshotTestCase/FBSnapshotTestCase.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.m
@@ -41,6 +41,17 @@
   _snapshotController.recordMode = recordMode;
 }
 
+- (BOOL)isDeviceAgnostic
+{
+  return _snapshotController.deviceAgnostic;
+}
+
+- (void)setDeviceAgnostic:(BOOL)deviceAgnostic
+{
+  NSAssert1(_snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
+  _snapshotController.deviceAgnostic = deviceAgnostic;
+}
+
 - (BOOL)usesDrawViewHierarchyInRect
 {
   return _snapshotController.usesDrawViewHierarchyInRect;

--- a/FBSnapshotTestCase/FBSnapshotTestCasePlatform.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCasePlatform.h
@@ -30,6 +30,14 @@ BOOL FBSnapshotTestCaseIs64Bit(void);
  @returns An @c NSOrderedSet object containing strings that are appended to the reference images directory.
  */
 NSOrderedSet *FBSnapshotTestCaseDefaultSuffixes(void);
+  
+/**
+ Returns a fully «normalized» file name.
+ Strips punctuation and spaces and replaces them with @c _. Also appends the device model, running OS and screen size to the file name.
+ 
+ @returns An @c NSString object containing the passed @c fileName with the device model, OS and screen size appended at the end.
+ */
+NSString *FBDeviceAgnosticNormalizedFileName(NSString *fileName);
 
 #ifdef __cplusplus
 }

--- a/FBSnapshotTestCase/FBSnapshotTestCasePlatform.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCasePlatform.m
@@ -9,6 +9,7 @@
  */
 
 #import <FBSnapshotTestCase/FBSnapshotTestCasePlatform.h>
+#import <UIKit/UIKit.h>
 
 BOOL FBSnapshotTestCaseIs64Bit(void)
 {
@@ -28,4 +29,21 @@ NSOrderedSet *FBSnapshotTestCaseDefaultSuffixes(void)
     return [suffixesSet reversedOrderedSet];
   } 
   return [suffixesSet copy];
+}
+
+NSString *FBDeviceAgnosticNormalizedFileName(NSString *fileName)
+{
+  UIDevice *device = [UIDevice currentDevice];
+  CGSize screenSize = [[UIApplication sharedApplication] keyWindow].bounds.size;
+  NSString *os = device.systemVersion;
+  
+  fileName = [NSString stringWithFormat:@"%@_%@%@_%.0fx%.0f", fileName, device.model, os, screenSize.width, screenSize.height];
+  
+  NSMutableCharacterSet *invalidCharacters = [NSMutableCharacterSet new];
+  [invalidCharacters formUnionWithCharacterSet:[NSCharacterSet whitespaceCharacterSet]];
+  [invalidCharacters formUnionWithCharacterSet:[NSCharacterSet punctuationCharacterSet]];
+  NSArray *validComponents = [fileName componentsSeparatedByCharactersInSet:invalidCharacters];
+  fileName = [validComponents componentsJoinedByString:@"_"];
+  
+  return fileName;
 }

--- a/FBSnapshotTestCase/FBSnapshotTestController.h
+++ b/FBSnapshotTestCase/FBSnapshotTestController.h
@@ -41,6 +41,12 @@ extern NSString *const FBReferenceImageFilePathKey;
 @property (readwrite, nonatomic, assign) BOOL recordMode;
 
 /**
+ When @c YES appends the name of the device model and OS to the snapshot file name.
+ The default value is @c NO.
+ */
+@property (readwrite, nonatomic, assign, getter=isDeviceAgnostic) BOOL deviceAgnostic;
+
+/**
  Uses drawViewHierarchyInRect:afterScreenUpdates: to draw the image instead of renderInContext:
  */
 @property (readwrite, nonatomic, assign) BOOL usesDrawViewHierarchyInRect;

--- a/FBSnapshotTestCase/FBSnapshotTestController.m
+++ b/FBSnapshotTestCase/FBSnapshotTestController.m
@@ -9,6 +9,7 @@
  */
 
 #import <FBSnapshotTestCase/FBSnapshotTestController.h>
+#import <FBSnapshotTestCase/FBSnapshotTestCasePlatform.h>
 #import <FBSnapshotTestCase/UIImage+Compare.h>
 #import <FBSnapshotTestCase/UIImage+Diff.h>
 #import <FBSnapshotTestCase/UIImage+Snapshot.h>
@@ -42,6 +43,8 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
 {
   if (self = [super init]) {
     _testName = [testName copy];
+    _deviceAgnostic = NO;
+    
     _fileManager = [[NSFileManager alloc] init];
   }
   return self;
@@ -226,6 +229,11 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
   if (0 < identifier.length) {
     fileName = [fileName stringByAppendingFormat:@"_%@", identifier];
   }
+  
+  if (self.isDeviceAgnostic) {
+    fileName = FBDeviceAgnosticNormalizedFileName(fileName);
+  }
+  
   if ([[UIScreen mainScreen] scale] > 1) {
     fileName = [fileName stringByAppendingFormat:@"@%.fx", [[UIScreen mainScreen] scale]];
   }

--- a/FBSnapshotTestCaseTests/FBSnapshotControllerTests.m
+++ b/FBSnapshotTestCaseTests/FBSnapshotControllerTests.m
@@ -10,6 +10,7 @@
 
 #import <XCTest/XCTest.h>
 #import "FBSnapshotTestController.h"
+#import "FBSnapshotTestCasePlatform.h"
 
 @interface FBSnapshotControllerTests : XCTestCase
 
@@ -63,6 +64,24 @@
     FBSnapshotTestController *controller = [[FBSnapshotTestController alloc] initWithTestClass:nil];
     // With some tolerance these should be considered the same
     XCTAssertTrue([controller compareReferenceImage:referenceImage toImage:testImage tolerance:.001 error:nil]);
+}
+
+- (void)testFailedImageWithDeviceAgnosticShouldHaveModelOnName
+{
+  UIImage *referenceImage = [self _bundledImageNamed:@"square" type:@"png"];
+  XCTAssertNotNil(referenceImage);
+  UIImage *testImage = [self _bundledImageNamed:@"square_with_pixel" type:@"png"];
+  XCTAssertNotNil(testImage);
+  
+  FBSnapshotTestController *controller = [[FBSnapshotTestController alloc] initWithTestClass:nil];
+  [controller setDeviceAgnostic:YES];
+  [controller setReferenceImagesDirectory:@"/dev/null/"];
+  NSError *error = nil;
+  SEL selector = @selector(isDeviceAgnostic);
+  [controller referenceImageForSelector:selector identifier:@"" error:&error];
+  XCTAssertNotNil(error);
+  NSString *deviceAgnosticReferencePath = FBDeviceAgnosticNormalizedFileName(NSStringFromSelector(selector));
+  XCTAssertTrue([(NSString *)[error.userInfo objectForKey:FBReferenceImageFilePathKey] containsString:deviceAgnosticReferencePath]);
 }
 
 #pragma mark - Private helper methods

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Features
   in a single test method.
 - Support for `CALayer` via `FBSnapshotVerifyLayer`.
 - `usesDrawViewHierarchyInRect` to handle cases like `UIVisualEffect`, `UIAppearance` and Size Classes.
+- `isDeviceAgnostic` to allow appending the device model (`iPhone`, `iPad`, `iPod Touch`, etc), OS version and screen size to the images (allowing to have multiple tests for the same «snapshot» for different `OS`s and devices).
 
 Notes
 -----


### PR DESCRIPTION
We like to actually record snapshots on multiple devices and multiple `OS`s (using bots for example is easier to automate testing on `iPad`/`iPhone` and a combination of different `OS`s).

Instead of having to manually pass the data to each test I added a new property:
`recordModelAndOSInName` which is used to check if those elements should be added to the recorded/retrieved image later on the comparison; resulting on an image name like the following:

> context_controller_being_tested_iPhone9_0.png

Probably the names of the functions & properties could use some imagination but the functionality is there.