### PR TITLE
Fix build for Xcode 7.1

### DIFF
--- a/FBSnapshotTestCase/FBSnapshotTestCase.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.h
@@ -8,8 +8,6 @@
  *
  */
 
-#import <FBSnapshotTestCase/FBSnapshotTestCasePlatform.h>
-
 #import <QuartzCore/QuartzCore.h>
 
 #import <UIKit/UIKit.h>


### PR DESCRIPTION
Avoids the error `"include of non-modular header inside framework module 'FBSnapshotTestCase'"`.