### PR TITLE
Fix Xcode 7.1 build errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.0.6
+
+  - Added modulemap and podspec fixes to build with Xcode 7.1 (#127)
+
 ## 2.0.5
 
   - Swift 2.0 (#111, #120) (Thanks to @pietbrauer and @grantjk)
@@ -33,13 +37,9 @@ All notable changes to this project will be documented in this file.
 
 ## 1.8.1
 
-### Fixed
-
   - Prevent mangling of C function names when compiled with a C++ compiler. (#79)
 
 ## 1.8.0
-
-### Changed
 
   - The default directories for snapshots images are now **ReferenceImages_32** (32bit) and **ReferenceImages_64** (64bit) and the suffix depends on the architecture when the test is running. (#77) 
   	- If a test fails for a given suffix, it will try to load and compare all other suffixes before failing.

--- a/FBSnapshotTestCase.modulemap
+++ b/FBSnapshotTestCase.modulemap
@@ -1,0 +1,15 @@
+framework module FBSnapshotTestCase {
+  umbrella header "FBSnapshotTestCase.h"
+
+  export *
+  module * { export * }
+
+  header "FBSnapshotTestCasePlatform.h"
+  header "FBSnapshotTestCase.h"
+
+  private header "UIImage+Compare.h"
+  private header "UIImage+Diff.h"
+  private header "UIImage+Snapshot.h"
+  private header "FBSnapshotTestController.h"
+}
+

--- a/FBSnapshotTestCase.podspec
+++ b/FBSnapshotTestCase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "FBSnapshotTestCase"
-  s.version      = "2.0.5"
+  s.version      = "2.0.6"
   s.summary      = "Snapshot view unit tests for iOS"
   s.description  = <<-DESC
                     A "snapshot test case" takes a configured UIView or CALayer
@@ -16,13 +16,14 @@ Pod::Spec.new do |s|
                      :tag => s.version.to_s }
   s.platform     = :ios, '7.0'
   s.requires_arc = true
-  s.framework    = 'XCTest'
+  s.frameworks    = 'XCTest','UIKit','Foundation','QuartzCore'
   s.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO' }
-  s.public_header_files = ['FBSnapshotTestCase/FBSnapshotTestCase.h', 'FBSnapshotTestCase/FBSnapshotTestCasePlatform.h']
-  s.private_header_files = ['FBSnapshotTestCase/FBSnapshotTestController.h', 'FBSnapshotTestCase/UIImage+Compare.h', 'FBSnapshotTestCase/UIImage+Diff.h']
   s.default_subspecs = 'SwiftSupport'
+  s.module_map = 'FBSnapshotTestCase.modulemap'
   s.subspec 'Core' do |cs|
-    cs.source_files = 'FBSnapshotTestCase/**/*.{h,m}'
+    cs.source_files = 'FBSnapshotTestCase/**/*.{h,m}', 'FBSnapshotTestCase/*.{h,m}'
+    cs.public_header_files = 'FBSnapshotTestCase/FBSnapshotTestCase.h','FBSnapshotTestCase/FBSnapshotTestCasePlatform.h'
+    cs.private_header_files = 'FBSnapshotTestCase/FBSnapshotTestController.h','FBSnapshotTestCase/Categories/UIImage+Compare.h','FBSnapshotTestCase/Categories/UIImage+Diff.h','FBSnapshotTestCase/Categories/UIImage+Snapshot.h'
   end
   s.subspec 'SwiftSupport' do |cs|
     cs.dependency 'FBSnapshotTestCase/Core'

--- a/FBSnapshotTestCaseDemo/Podfile.lock
+++ b/FBSnapshotTestCaseDemo/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - FBSnapshotTestCase (2.0.5):
-    - FBSnapshotTestCase/SwiftSupport (= 2.0.5)
-  - FBSnapshotTestCase/Core (2.0.5)
-  - FBSnapshotTestCase/SwiftSupport (2.0.5):
+  - FBSnapshotTestCase (2.0.6):
+    - FBSnapshotTestCase/SwiftSupport (= 2.0.6)
+  - FBSnapshotTestCase/Core (2.0.6)
+  - FBSnapshotTestCase/SwiftSupport (2.0.6):
     - FBSnapshotTestCase/Core
 
 DEPENDENCIES:
@@ -13,6 +13,6 @@ EXTERNAL SOURCES:
     :path: ".."
 
 SPEC CHECKSUMS:
-  FBSnapshotTestCase: 6917deb01d0556dd544536f9eb34e0cf26f904d5
+  FBSnapshotTestCase: f53793e19b2782f2948e8597b03ec2bb5aedf5cd
 
 COCOAPODS: 0.39.0


### PR DESCRIPTION
The podspec wasn't configured correctly which caused builds errors with the latest version of Xcode (7.1) as reported (#125)