### PR TITLE
Expose FBSnapshotTestController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.0.7
+
+  - Change FBSnapshotTestController from private to public (#129)
+
 ## 2.0.6
 
   - Added modulemap and podspec fixes to build with Xcode 7.1 (#127)

--- a/FBSnapshotTestCase.modulemap
+++ b/FBSnapshotTestCase.modulemap
@@ -4,12 +4,12 @@ framework module FBSnapshotTestCase {
   export *
   module * { export * }
 
-  header "FBSnapshotTestCasePlatform.h"
   header "FBSnapshotTestCase.h"
+  header "FBSnapshotTestCasePlatform.h"
+  header "FBSnapshotTestController.h"
 
   private header "UIImage+Compare.h"
   private header "UIImage+Diff.h"
   private header "UIImage+Snapshot.h"
-  private header "FBSnapshotTestController.h"
 }
 

--- a/FBSnapshotTestCase.podspec
+++ b/FBSnapshotTestCase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "FBSnapshotTestCase"
-  s.version      = "2.0.6"
+  s.version      = "2.0.7"
   s.summary      = "Snapshot view unit tests for iOS"
   s.description  = <<-DESC
                     A "snapshot test case" takes a configured UIView or CALayer
@@ -22,8 +22,8 @@ Pod::Spec.new do |s|
   s.module_map = 'FBSnapshotTestCase.modulemap'
   s.subspec 'Core' do |cs|
     cs.source_files = 'FBSnapshotTestCase/**/*.{h,m}', 'FBSnapshotTestCase/*.{h,m}'
-    cs.public_header_files = 'FBSnapshotTestCase/FBSnapshotTestCase.h','FBSnapshotTestCase/FBSnapshotTestCasePlatform.h'
-    cs.private_header_files = 'FBSnapshotTestCase/FBSnapshotTestController.h','FBSnapshotTestCase/Categories/UIImage+Compare.h','FBSnapshotTestCase/Categories/UIImage+Diff.h','FBSnapshotTestCase/Categories/UIImage+Snapshot.h'
+    cs.public_header_files = 'FBSnapshotTestCase/FBSnapshotTestCase.h','FBSnapshotTestCase/FBSnapshotTestCasePlatform.h','FBSnapshotTestCase/FBSnapshotTestController.h'
+    cs.private_header_files = 'FBSnapshotTestCase/Categories/UIImage+Compare.h','FBSnapshotTestCase/Categories/UIImage+Diff.h','FBSnapshotTestCase/Categories/UIImage+Snapshot.h'
   end
   s.subspec 'SwiftSupport' do |cs|
     cs.dependency 'FBSnapshotTestCase/Core'


### PR DESCRIPTION
With #127 I made FBSnapshotTestController private but it seems that there are usages publicly already. I am exposing this again to avoid this breaking change.