### PR TITLE
Enabling reference images specific to a device

### DIFF
--- a/FBSnapshotTestCase/FBSnapshotTestCase.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.h
@@ -144,6 +144,13 @@
  */
 @property (readwrite, nonatomic, assign) BOOL usesDrawViewHierarchyInRect;
 
+/**
+ When YES, will generate (test against, respectively) device specific reference images.
+ For example, if tests are run on the iPhone 5s simulator, views will be compared to reference images specific to
+ the iPhone 5s, and not ones generated for iPhone 6 Plus.
+ */
+@property (readwrite, nonatomic, assign) BOOL deviceSpecificCase;
+
 - (void)setUp NS_REQUIRES_SUPER;
 - (void)tearDown NS_REQUIRES_SUPER;
 

--- a/FBSnapshotTestCase/FBSnapshotTestCase.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.m
@@ -63,6 +63,15 @@
   _snapshotController.usesDrawViewHierarchyInRect = usesDrawViewHierarchyInRect;
 }
 
+- (BOOL)deviceSpecificCase {
+    return _snapshotController.deviceSpecificCase;
+}
+
+- (void)setDeviceSpecificCase:(BOOL)deviceSpecificCase {
+    NSAssert1(_snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
+    _snapshotController.deviceSpecificCase = deviceSpecificCase;
+}
+
 #pragma mark - Public API
 
 - (BOOL)compareSnapshotOfLayer:(CALayer *)layer

--- a/FBSnapshotTestCase/FBSnapshotTestController.h
+++ b/FBSnapshotTestCase/FBSnapshotTestController.h
@@ -52,6 +52,11 @@ extern NSString *const FBReferenceImageFilePathKey;
 @property (readwrite, nonatomic, assign) BOOL usesDrawViewHierarchyInRect;
 
 /**
+ Generates / compares against difference reference images depending on the device type (e.g. iPhone 6)
+ */
+@property (readwrite, nonatomic, assign) BOOL deviceSpecificCase;
+
+/**
  The directory in which referfence images are stored.
  */
 @property (readwrite, nonatomic, copy) NSString *referenceImagesDirectory;

--- a/FBSnapshotTestCase/FBSnapshotTestController.m
+++ b/FBSnapshotTestCase/FBSnapshotTestController.m
@@ -15,6 +15,7 @@
 #import <FBSnapshotTestCase/UIImage+Snapshot.h>
 
 #import <UIKit/UIKit.h>
+#import <sys/utsname.h>
 
 NSString *const FBSnapshotTestControllerErrorDomain = @"FBSnapshotTestControllerErrorDomain";
 NSString *const FBReferenceImageFilePathKey = @"FBReferenceImageFilePathKey";
@@ -237,8 +238,35 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
   if ([[UIScreen mainScreen] scale] > 1) {
     fileName = [fileName stringByAppendingFormat:@"@%.fx", [[UIScreen mainScreen] scale]];
   }
+  if (self.deviceSpecificCase) {
+    fileName = [fileName stringByAppendingString:[self _deviceName]];
+  }
   fileName = [fileName stringByAppendingPathExtension:@"png"];
   return fileName;
+}
+
+- (NSString*) _hardwareDeviceName
+{
+    struct utsname systemInfo;
+    uname(&systemInfo);
+    
+    return [NSString stringWithCString:systemInfo.machine
+                              encoding:NSUTF8StringEncoding];
+}
+
+- (NSString *)_deviceName {
+    NSString* deviceName = [self _hardwareDeviceName];
+    if ([deviceName isEqualToString:@"i386"] ||
+        [deviceName isEqualToString:@"x86_64"]) {
+        // this means the simulator is used
+        
+        // using SIMULATOR_MODEL_IDENTIFIER is not a deterministic way
+        // to get the Simulator name used at runtime, but there doesn't seem to
+        // be a better way
+        deviceName = [NSString stringWithCString:getenv("SIMULATOR_MODEL_IDENTIFIER")
+                                        encoding:NSUTF8StringEncoding];
+    }
+    return deviceName;
 }
 
 - (NSString *)_referenceFilePathForSelector:(SEL)selector


### PR DESCRIPTION
I think it can be useful to have reference images specific to a certain device.

For example tests with reference image created by the iPhone 5 simulator sometimes fail on iPhone 6 since it has more real estate to fit text.

For CI it is a good idea to test all different phone sizes, namely iPhone 4s, iPhone 5, iPhone 6, iPhone 6 Plus. However, currently the only differentiation FBSnapshotTestCase makes is between scale factors.

P.S. I've tried to follow the code style used for the `usesDrawViewHierarchyInRect` property. However, it might be better if all code for extracting the device/simulator name is extracted in a class.

Also, it might be helpful to be able to set the `deviceSpecificCase` property globally for all test suites (via a static member or environmental variable).

If you agree, I'd be happy to modify the pull request.