### PR TITLE
If a view is a UIWindow, then don't re-wrap it in a UIWindow before call to drawViewHierarchy

### DIFF
--- a/FBSnapshotTestCase/Categories/UIImage+Snapshot.m
+++ b/FBSnapshotTestCase/Categories/UIImage+Snapshot.m
@@ -43,7 +43,8 @@
   NSAssert1(CGRectGetWidth(bounds), @"Zero width for view %@", view);
   NSAssert1(CGRectGetHeight(bounds), @"Zero height for view %@", view);  
 
-  UIWindow *window = view.window;
+  // If the input view is already a UIWindow, then just use that. Otherwise wrap in a window.
+  UIWindow *window = [view isKindOfClass:[UIWindow class]] ? (UIWindow *)view : view.window;
   if (window == nil) {
     window = [[UIWindow alloc] initWithFrame:bounds];
     [window addSubview:view];


### PR DESCRIPTION
When usesDrawViewHierarchyInRect is YES, the UIView is added to a UIWindow before it is drawn into the image context. However, if the UIView _is_ a UIWindow, then wrapping it in a window will cause issues.

This simply uses the view directly if it is already a UIWindow.