### PR TITLE
Propagate correct file name and line number from Swift

### DIFF
--- a/FBSnapshotTestCase/SwiftSupport.swift
+++ b/FBSnapshotTestCase/SwiftSupport.swift
@@ -10,11 +10,11 @@
 
 public extension FBSnapshotTestCase {
   public func FBSnapshotVerifyView(view: UIView, identifier: String = "", suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), file: String = __FILE__, line: UInt = __LINE__) {
-    FBSnapshotVerifyViewOrLayer(view, identifier: identifier, suffixes: suffixes)
+    FBSnapshotVerifyViewOrLayer(view, identifier: identifier, suffixes: suffixes, file: file, line: line)
   }
 
   public func FBSnapshotVerifyLayer(layer: CALayer, identifier: String = "", suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), file: String = __FILE__, line: UInt = __LINE__) {
-    FBSnapshotVerifyViewOrLayer(layer, identifier: identifier, suffixes: suffixes)
+    FBSnapshotVerifyViewOrLayer(layer, identifier: identifier, suffixes: suffixes, file: file, line: line)
   }
 
   private func FBSnapshotVerifyViewOrLayer(viewOrLayer: AnyObject, identifier: String = "", suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), file: String = __FILE__, line: UInt = __LINE__) {


### PR DESCRIPTION
File name and line number have to be passed through from the public methods to the underlying private method, otherwise they will point to the line numbers in the `SwiftSupport.swift` file.