### PR TITLE
Add and configure tvOS framework target

### DIFF
--- a/FBSnapshotTestCase.xcodeproj/project.pbxproj
+++ b/FBSnapshotTestCase.xcodeproj/project.pbxproj
@@ -15,6 +15,27 @@
 		1335641B1B59C3F500A4E4BF /* UIImage+Snapshot.m in Sources */ = {isa = PBXBuildFile; fileRef = 133564151B59C3F500A4E4BF /* UIImage+Snapshot.m */; };
 		13CBB39D1AEE013900B6ADBA /* FBSnapshotTestCasePlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = 13CBB39B1AEE013900B6ADBA /* FBSnapshotTestCasePlatform.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		13CBB39E1AEE013900B6ADBA /* FBSnapshotTestCasePlatform.m in Sources */ = {isa = PBXBuildFile; fileRef = 13CBB39C1AEE013900B6ADBA /* FBSnapshotTestCasePlatform.m */; };
+		827137841C63AB7000354E42 /* FBSnapshotTestCase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8271377A1C63AB6F00354E42 /* FBSnapshotTestCase.framework */; };
+		827137911C63ABE900354E42 /* UIImage+Compare.h in Headers */ = {isa = PBXBuildFile; fileRef = 133564101B59C3F500A4E4BF /* UIImage+Compare.h */; };
+		827137921C63ABF000354E42 /* UIImage+Diff.h in Headers */ = {isa = PBXBuildFile; fileRef = 133564121B59C3F500A4E4BF /* UIImage+Diff.h */; };
+		827137931C63ABF000354E42 /* UIImage+Snapshot.h in Headers */ = {isa = PBXBuildFile; fileRef = 133564141B59C3F500A4E4BF /* UIImage+Snapshot.h */; };
+		827137941C63ABF000354E42 /* UIApplication+StrictKeyWindow.h in Headers */ = {isa = PBXBuildFile; fileRef = BC45D51F1C2AEFCE007C72F3 /* UIApplication+StrictKeyWindow.h */; };
+		827137951C63ABF400354E42 /* UIImage+Compare.m in Sources */ = {isa = PBXBuildFile; fileRef = 133564111B59C3F500A4E4BF /* UIImage+Compare.m */; };
+		827137961C63ABF400354E42 /* UIImage+Diff.m in Sources */ = {isa = PBXBuildFile; fileRef = 133564131B59C3F500A4E4BF /* UIImage+Diff.m */; };
+		827137971C63ABF400354E42 /* UIImage+Snapshot.m in Sources */ = {isa = PBXBuildFile; fileRef = 133564151B59C3F500A4E4BF /* UIImage+Snapshot.m */; };
+		827137981C63ABF400354E42 /* UIApplication+StrictKeyWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = BC45D5201C2AEFCE007C72F3 /* UIApplication+StrictKeyWindow.m */; };
+		827137991C63ABF900354E42 /* FBSnapshotTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = B31988201AB7849400B0A900 /* FBSnapshotTestCase.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8271379A1C63ABF900354E42 /* FBSnapshotTestCasePlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = 13CBB39B1AEE013900B6ADBA /* FBSnapshotTestCasePlatform.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8271379B1C63ABF900354E42 /* FBSnapshotTestController.h in Headers */ = {isa = PBXBuildFile; fileRef = B31988221AB7849400B0A900 /* FBSnapshotTestController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8271379C1C63ABFD00354E42 /* FBSnapshotTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = B31988211AB7849400B0A900 /* FBSnapshotTestCase.m */; };
+		8271379D1C63ABFD00354E42 /* FBSnapshotTestCasePlatform.m in Sources */ = {isa = PBXBuildFile; fileRef = 13CBB39C1AEE013900B6ADBA /* FBSnapshotTestCasePlatform.m */; };
+		8271379E1C63ABFD00354E42 /* FBSnapshotTestController.m in Sources */ = {isa = PBXBuildFile; fileRef = B31988231AB7849400B0A900 /* FBSnapshotTestController.m */; };
+		8271379F1C63AC0000354E42 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D698F41B204E120005CAC9 /* SwiftSupport.swift */; };
+		827137A01C63AC0700354E42 /* square_with_pixel.png in Resources */ = {isa = PBXBuildFile; fileRef = E5C2CD611B1F399A00669887 /* square_with_pixel.png */; };
+		827137A11C63AC0900354E42 /* square_with_text.png in Resources */ = {isa = PBXBuildFile; fileRef = B32447D91AB78B5E00B1D6FF /* square_with_text.png */; };
+		827137A21C63AC0D00354E42 /* square-copy.png in Resources */ = {isa = PBXBuildFile; fileRef = B32447DA1AB78B5E00B1D6FF /* square-copy.png */; };
+		827137A31C63AC0D00354E42 /* square.png in Resources */ = {isa = PBXBuildFile; fileRef = B32447DB1AB78B5E00B1D6FF /* square.png */; };
+		827137A41C63AC0F00354E42 /* FBSnapshotControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B31988301AB784CB00B0A900 /* FBSnapshotControllerTests.m */; };
 		B31987FC1AB782D100B0A900 /* FBSnapshotTestCase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B31987F01AB782D000B0A900 /* FBSnapshotTestCase.framework */; };
 		B31988281AB7849400B0A900 /* FBSnapshotTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = B31988201AB7849400B0A900 /* FBSnapshotTestCase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B31988291AB7849400B0A900 /* FBSnapshotTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = B31988211AB7849400B0A900 /* FBSnapshotTestCase.m */; };
@@ -31,6 +52,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		827137851C63AB7000354E42 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B31987E71AB782D000B0A900 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 827137791C63AB6F00354E42;
+			remoteInfo = "FBSnapshotTestCase tvOS";
+		};
 		B31987FD1AB782D100B0A900 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B31987E71AB782D000B0A900 /* Project object */;
@@ -49,9 +77,11 @@
 		133564151B59C3F500A4E4BF /* UIImage+Snapshot.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Snapshot.m"; sourceTree = "<group>"; };
 		13CBB39B1AEE013900B6ADBA /* FBSnapshotTestCasePlatform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSnapshotTestCasePlatform.h; sourceTree = "<group>"; };
 		13CBB39C1AEE013900B6ADBA /* FBSnapshotTestCasePlatform.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSnapshotTestCasePlatform.m; sourceTree = "<group>"; };
+		8271377A1C63AB6F00354E42 /* FBSnapshotTestCase.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FBSnapshotTestCase.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		827137831C63AB7000354E42 /* FBSnapshotTestCase tvOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "FBSnapshotTestCase tvOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B31987F01AB782D000B0A900 /* FBSnapshotTestCase.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FBSnapshotTestCase.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B31987F41AB782D000B0A900 /* FBSnapshotTestCase-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "FBSnapshotTestCase-Info.plist"; sourceTree = "<group>"; };
-		B31987FB1AB782D100B0A900 /* FBSnapshotTestCaseTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FBSnapshotTestCaseTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		B31987FB1AB782D100B0A900 /* FBSnapshotTestCase iOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "FBSnapshotTestCase iOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B31988011AB782D100B0A900 /* FBSnapshotTestCaseTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "FBSnapshotTestCaseTests-Info.plist"; sourceTree = "<group>"; };
 		B31988201AB7849400B0A900 /* FBSnapshotTestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSnapshotTestCase.h; sourceTree = "<group>"; };
 		B31988211AB7849400B0A900 /* FBSnapshotTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSnapshotTestCase.m; sourceTree = "<group>"; };
@@ -68,6 +98,21 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		827137761C63AB6F00354E42 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		827137801C63AB7000354E42 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				827137841C63AB7000354E42 /* FBSnapshotTestCase.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B31987EC1AB782D000B0A900 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -104,8 +149,8 @@
 		B31987E61AB782D000B0A900 = {
 			isa = PBXGroup;
 			children = (
-				B31987F21AB782D000B0A900 /* FBSnapshotTestCase */,
-				B31987FF1AB782D100B0A900 /* FBSnapshotTestCaseTests */,
+				B31987F21AB782D000B0A900 /* Sources */,
+				B31987FF1AB782D100B0A900 /* Tests */,
 				B31987F11AB782D000B0A900 /* Products */,
 			);
 			indentWidth = 2;
@@ -116,12 +161,14 @@
 			isa = PBXGroup;
 			children = (
 				B31987F01AB782D000B0A900 /* FBSnapshotTestCase.framework */,
-				B31987FB1AB782D100B0A900 /* FBSnapshotTestCaseTests.xctest */,
+				B31987FB1AB782D100B0A900 /* FBSnapshotTestCase iOS Tests.xctest */,
+				8271377A1C63AB6F00354E42 /* FBSnapshotTestCase.framework */,
+				827137831C63AB7000354E42 /* FBSnapshotTestCase tvOS Tests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
 		};
-		B31987F21AB782D000B0A900 /* FBSnapshotTestCase */ = {
+		B31987F21AB782D000B0A900 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
 				1335640F1B59C3F500A4E4BF /* Categories */,
@@ -134,6 +181,7 @@
 				F0D698F41B204E120005CAC9 /* SwiftSupport.swift */,
 				B31987F31AB782D000B0A900 /* Supporting Files */,
 			);
+			name = Sources;
 			path = FBSnapshotTestCase;
 			sourceTree = "<group>";
 		};
@@ -145,7 +193,7 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
-		B31987FF1AB782D100B0A900 /* FBSnapshotTestCaseTests */ = {
+		B31987FF1AB782D100B0A900 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
 				E5C2CD611B1F399A00669887 /* square_with_pixel.png */,
@@ -155,6 +203,7 @@
 				B31988301AB784CB00B0A900 /* FBSnapshotControllerTests.m */,
 				B31988001AB782D100B0A900 /* Supporting Files */,
 			);
+			name = Tests;
 			path = FBSnapshotTestCaseTests;
 			sourceTree = "<group>";
 		};
@@ -169,6 +218,20 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		827137771C63AB6F00354E42 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				827137941C63ABF000354E42 /* UIApplication+StrictKeyWindow.h in Headers */,
+				8271379A1C63ABF900354E42 /* FBSnapshotTestCasePlatform.h in Headers */,
+				827137911C63ABE900354E42 /* UIImage+Compare.h in Headers */,
+				827137991C63ABF900354E42 /* FBSnapshotTestCase.h in Headers */,
+				8271379B1C63ABF900354E42 /* FBSnapshotTestController.h in Headers */,
+				827137931C63ABF000354E42 /* UIImage+Snapshot.h in Headers */,
+				827137921C63ABF000354E42 /* UIImage+Diff.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B31987ED1AB782D000B0A900 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -186,9 +249,45 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		B31987EF1AB782D000B0A900 /* FBSnapshotTestCase */ = {
+		827137791C63AB6F00354E42 /* FBSnapshotTestCase tvOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = B31988061AB782D100B0A900 /* Build configuration list for PBXNativeTarget "FBSnapshotTestCase" */;
+			buildConfigurationList = 8271378F1C63AB7000354E42 /* Build configuration list for PBXNativeTarget "FBSnapshotTestCase tvOS" */;
+			buildPhases = (
+				827137751C63AB6F00354E42 /* Sources */,
+				827137761C63AB6F00354E42 /* Frameworks */,
+				827137771C63AB6F00354E42 /* Headers */,
+				827137781C63AB6F00354E42 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "FBSnapshotTestCase tvOS";
+			productName = "FBSnapshotTestCase tvOS";
+			productReference = 8271377A1C63AB6F00354E42 /* FBSnapshotTestCase.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		827137821C63AB7000354E42 /* FBSnapshotTestCase tvOS Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 827137901C63AB7000354E42 /* Build configuration list for PBXNativeTarget "FBSnapshotTestCase tvOS Tests" */;
+			buildPhases = (
+				8271377F1C63AB7000354E42 /* Sources */,
+				827137801C63AB7000354E42 /* Frameworks */,
+				827137811C63AB7000354E42 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				827137861C63AB7000354E42 /* PBXTargetDependency */,
+			);
+			name = "FBSnapshotTestCase tvOS Tests";
+			productName = "FBSnapshotTestCase tvOSTests";
+			productReference = 827137831C63AB7000354E42 /* FBSnapshotTestCase tvOS Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		B31987EF1AB782D000B0A900 /* FBSnapshotTestCase iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B31988061AB782D100B0A900 /* Build configuration list for PBXNativeTarget "FBSnapshotTestCase iOS" */;
 			buildPhases = (
 				B31987EB1AB782D000B0A900 /* Sources */,
 				B31987EC1AB782D000B0A900 /* Frameworks */,
@@ -199,14 +298,14 @@
 			);
 			dependencies = (
 			);
-			name = FBSnapshotTestCase;
+			name = "FBSnapshotTestCase iOS";
 			productName = FBSnapshotTestCase;
 			productReference = B31987F01AB782D000B0A900 /* FBSnapshotTestCase.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		B31987FA1AB782D100B0A900 /* FBSnapshotTestCaseTests */ = {
+		B31987FA1AB782D100B0A900 /* FBSnapshotTestCase iOS Tests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = B31988091AB782D100B0A900 /* Build configuration list for PBXNativeTarget "FBSnapshotTestCaseTests" */;
+			buildConfigurationList = B31988091AB782D100B0A900 /* Build configuration list for PBXNativeTarget "FBSnapshotTestCase iOS Tests" */;
 			buildPhases = (
 				B31987F71AB782D100B0A900 /* Sources */,
 				B31987F81AB782D100B0A900 /* Frameworks */,
@@ -217,9 +316,9 @@
 			dependencies = (
 				B31987FE1AB782D100B0A900 /* PBXTargetDependency */,
 			);
-			name = FBSnapshotTestCaseTests;
+			name = "FBSnapshotTestCase iOS Tests";
 			productName = FBSnapshotTestCaseTests;
-			productReference = B31987FB1AB782D100B0A900 /* FBSnapshotTestCaseTests.xctest */;
+			productReference = B31987FB1AB782D100B0A900 /* FBSnapshotTestCase iOS Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
@@ -229,10 +328,16 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftMigration = 0700;
-				LastSwiftUpdateCheck = 0700;
+				LastSwiftUpdateCheck = 0720;
 				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = Facebook;
 				TargetAttributes = {
+					827137791C63AB6F00354E42 = {
+						CreatedOnToolsVersion = 7.2;
+					};
+					827137821C63AB7000354E42 = {
+						CreatedOnToolsVersion = 7.2;
+					};
 					B31987EF1AB782D000B0A900 = {
 						CreatedOnToolsVersion = 6.1.1;
 					};
@@ -253,13 +358,33 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				B31987EF1AB782D000B0A900 /* FBSnapshotTestCase */,
-				B31987FA1AB782D100B0A900 /* FBSnapshotTestCaseTests */,
+				B31987EF1AB782D000B0A900 /* FBSnapshotTestCase iOS */,
+				B31987FA1AB782D100B0A900 /* FBSnapshotTestCase iOS Tests */,
+				827137791C63AB6F00354E42 /* FBSnapshotTestCase tvOS */,
+				827137821C63AB7000354E42 /* FBSnapshotTestCase tvOS Tests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		827137781C63AB6F00354E42 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		827137811C63AB7000354E42 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				827137A01C63AC0700354E42 /* square_with_pixel.png in Resources */,
+				827137A21C63AC0D00354E42 /* square-copy.png in Resources */,
+				827137A31C63AC0D00354E42 /* square.png in Resources */,
+				827137A11C63AC0900354E42 /* square_with_text.png in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B31987EE1AB782D000B0A900 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -281,6 +406,29 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		827137751C63AB6F00354E42 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				827137961C63ABF400354E42 /* UIImage+Diff.m in Sources */,
+				8271379E1C63ABFD00354E42 /* FBSnapshotTestController.m in Sources */,
+				827137981C63ABF400354E42 /* UIApplication+StrictKeyWindow.m in Sources */,
+				8271379D1C63ABFD00354E42 /* FBSnapshotTestCasePlatform.m in Sources */,
+				8271379C1C63ABFD00354E42 /* FBSnapshotTestCase.m in Sources */,
+				827137951C63ABF400354E42 /* UIImage+Compare.m in Sources */,
+				827137971C63ABF400354E42 /* UIImage+Snapshot.m in Sources */,
+				8271379F1C63AC0000354E42 /* SwiftSupport.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8271377F1C63AB7000354E42 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				827137A41C63AC0F00354E42 /* FBSnapshotControllerTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B31987EB1AB782D000B0A900 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -307,14 +455,110 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		827137861C63AB7000354E42 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 827137791C63AB6F00354E42 /* FBSnapshotTestCase tvOS */;
+			targetProxy = 827137851C63AB7000354E42 /* PBXContainerItemProxy */;
+		};
 		B31987FE1AB782D100B0A900 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = B31987EF1AB782D000B0A900 /* FBSnapshotTestCase */;
+			target = B31987EF1AB782D000B0A900 /* FBSnapshotTestCase iOS */;
 			targetProxy = B31987FD1AB782D100B0A900 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		8271378B1C63AB7000354E42 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/FBSnapshotTestCase/FBSnapshotTestCase-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					XCTest,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.FBSnapshotTestCase-tvOS";
+				PRODUCT_NAME = FBSnapshotTestCase;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		8271378C1C63AB7000354E42 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/FBSnapshotTestCase/FBSnapshotTestCase-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					XCTest,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.FBSnapshotTestCase-tvOS";
+				PRODUCT_NAME = FBSnapshotTestCase;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Release;
+		};
+		8271378D1C63AB7000354E42 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "FBSnapshotTestCaseTests/FBSnapshotTestCaseTests-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.FBSnapshotTestCase-tvOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TVOS_DEPLOYMENT_TARGET = 9.1;
+			};
+			name = Debug;
+		};
+		8271378E1C63AB7000354E42 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "FBSnapshotTestCaseTests/FBSnapshotTestCaseTests-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.FBSnapshotTestCase-tvOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				TVOS_DEPLOYMENT_TARGET = 9.1;
+			};
+			name = Release;
+		};
 		B31988041AB782D100B0A900 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -421,8 +665,8 @@
 					"-framework",
 					XCTest,
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.FBSnapshotTestCase;
+				PRODUCT_NAME = FBSnapshotTestCase;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -448,8 +692,8 @@
 					"-framework",
 					XCTest,
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.FBSnapshotTestCase;
+				PRODUCT_NAME = FBSnapshotTestCase;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;
@@ -489,6 +733,22 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		8271378F1C63AB7000354E42 /* Build configuration list for PBXNativeTarget "FBSnapshotTestCase tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8271378B1C63AB7000354E42 /* Debug */,
+				8271378C1C63AB7000354E42 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		827137901C63AB7000354E42 /* Build configuration list for PBXNativeTarget "FBSnapshotTestCase tvOS Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8271378D1C63AB7000354E42 /* Debug */,
+				8271378E1C63AB7000354E42 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		B31987EA1AB782D000B0A900 /* Build configuration list for PBXProject "FBSnapshotTestCase" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -498,7 +758,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		B31988061AB782D100B0A900 /* Build configuration list for PBXNativeTarget "FBSnapshotTestCase" */ = {
+		B31988061AB782D100B0A900 /* Build configuration list for PBXNativeTarget "FBSnapshotTestCase iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				B31988071AB782D100B0A900 /* Debug */,
@@ -507,7 +767,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		B31988091AB782D100B0A900 /* Build configuration list for PBXNativeTarget "FBSnapshotTestCaseTests" */ = {
+		B31988091AB782D100B0A900 /* Build configuration list for PBXNativeTarget "FBSnapshotTestCase iOS Tests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				B319880A1AB782D100B0A900 /* Debug */,

--- a/FBSnapshotTestCase.xcodeproj/xcshareddata/xcschemes/FBSnapshotTestCase iOS.xcscheme
+++ b/FBSnapshotTestCase.xcodeproj/xcshareddata/xcschemes/FBSnapshotTestCase iOS.xcscheme
@@ -15,8 +15,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "B31987EF1AB782D000B0A900"
-               BuildableName = "FBSnapshotTestCase.framework"
-               BlueprintName = "FBSnapshotTestCase"
+               BuildableName = "FBSnapshotTestCase iOS.framework"
+               BlueprintName = "FBSnapshotTestCase iOS"
                ReferencedContainer = "container:FBSnapshotTestCase.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -29,8 +29,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "B31987FA1AB782D100B0A900"
-               BuildableName = "FBSnapshotTestCaseTests.xctest"
-               BlueprintName = "FBSnapshotTestCaseTests"
+               BuildableName = "FBSnapshotTestCase iOS Tests.xctest"
+               BlueprintName = "FBSnapshotTestCase iOS Tests"
                ReferencedContainer = "container:FBSnapshotTestCase.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -47,8 +47,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "B31987FA1AB782D100B0A900"
-               BuildableName = "FBSnapshotTestCaseTests.xctest"
-               BlueprintName = "FBSnapshotTestCaseTests"
+               BuildableName = "FBSnapshotTestCase iOS Tests.xctest"
+               BlueprintName = "FBSnapshotTestCase iOS Tests"
                ReferencedContainer = "container:FBSnapshotTestCase.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -57,8 +57,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "B31987EF1AB782D000B0A900"
-            BuildableName = "FBSnapshotTestCase.framework"
-            BlueprintName = "FBSnapshotTestCase"
+            BuildableName = "FBSnapshotTestCase iOS.framework"
+            BlueprintName = "FBSnapshotTestCase iOS"
             ReferencedContainer = "container:FBSnapshotTestCase.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -79,8 +79,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "B31987EF1AB782D000B0A900"
-            BuildableName = "FBSnapshotTestCase.framework"
-            BlueprintName = "FBSnapshotTestCase"
+            BuildableName = "FBSnapshotTestCase iOS.framework"
+            BlueprintName = "FBSnapshotTestCase iOS"
             ReferencedContainer = "container:FBSnapshotTestCase.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -97,8 +97,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "B31987EF1AB782D000B0A900"
-            BuildableName = "FBSnapshotTestCase.framework"
-            BlueprintName = "FBSnapshotTestCase"
+            BuildableName = "FBSnapshotTestCase iOS.framework"
+            BlueprintName = "FBSnapshotTestCase iOS"
             ReferencedContainer = "container:FBSnapshotTestCase.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/FBSnapshotTestCase.xcodeproj/xcshareddata/xcschemes/FBSnapshotTestCase iOS.xcscheme
+++ b/FBSnapshotTestCase.xcodeproj/xcshareddata/xcschemes/FBSnapshotTestCase iOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "B31987EF1AB782D000B0A900"
-               BuildableName = "FBSnapshotTestCase iOS.framework"
+               BuildableName = "FBSnapshotTestCase.framework"
                BlueprintName = "FBSnapshotTestCase iOS"
                ReferencedContainer = "container:FBSnapshotTestCase.xcodeproj">
             </BuildableReference>
@@ -57,7 +57,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "B31987EF1AB782D000B0A900"
-            BuildableName = "FBSnapshotTestCase iOS.framework"
+            BuildableName = "FBSnapshotTestCase.framework"
             BlueprintName = "FBSnapshotTestCase iOS"
             ReferencedContainer = "container:FBSnapshotTestCase.xcodeproj">
          </BuildableReference>
@@ -79,7 +79,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "B31987EF1AB782D000B0A900"
-            BuildableName = "FBSnapshotTestCase iOS.framework"
+            BuildableName = "FBSnapshotTestCase.framework"
             BlueprintName = "FBSnapshotTestCase iOS"
             ReferencedContainer = "container:FBSnapshotTestCase.xcodeproj">
          </BuildableReference>
@@ -97,7 +97,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "B31987EF1AB782D000B0A900"
-            BuildableName = "FBSnapshotTestCase iOS.framework"
+            BuildableName = "FBSnapshotTestCase.framework"
             BlueprintName = "FBSnapshotTestCase iOS"
             ReferencedContainer = "container:FBSnapshotTestCase.xcodeproj">
          </BuildableReference>

--- a/FBSnapshotTestCase.xcodeproj/xcshareddata/xcschemes/FBSnapshotTestCase tvOS.xcscheme
+++ b/FBSnapshotTestCase.xcodeproj/xcshareddata/xcschemes/FBSnapshotTestCase tvOS.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "827137791C63AB6F00354E42"
+               BuildableName = "FBSnapshotTestCase tvOS.framework"
+               BlueprintName = "FBSnapshotTestCase tvOS"
+               ReferencedContainer = "container:FBSnapshotTestCase.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "827137821C63AB7000354E42"
+               BuildableName = "FBSnapshotTestCase tvOS Tests.xctest"
+               BlueprintName = "FBSnapshotTestCase tvOS Tests"
+               ReferencedContainer = "container:FBSnapshotTestCase.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "827137791C63AB6F00354E42"
+            BuildableName = "FBSnapshotTestCase tvOS.framework"
+            BlueprintName = "FBSnapshotTestCase tvOS"
+            ReferencedContainer = "container:FBSnapshotTestCase.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "827137791C63AB6F00354E42"
+            BuildableName = "FBSnapshotTestCase tvOS.framework"
+            BlueprintName = "FBSnapshotTestCase tvOS"
+            ReferencedContainer = "container:FBSnapshotTestCase.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "827137791C63AB6F00354E42"
+            BuildableName = "FBSnapshotTestCase tvOS.framework"
+            BlueprintName = "FBSnapshotTestCase tvOS"
+            ReferencedContainer = "container:FBSnapshotTestCase.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/FBSnapshotTestCase.xcodeproj/xcshareddata/xcschemes/FBSnapshotTestCase tvOS.xcscheme
+++ b/FBSnapshotTestCase.xcodeproj/xcshareddata/xcschemes/FBSnapshotTestCase tvOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "827137791C63AB6F00354E42"
-               BuildableName = "FBSnapshotTestCase tvOS.framework"
+               BuildableName = "FBSnapshotTestCase.framework"
                BlueprintName = "FBSnapshotTestCase tvOS"
                ReferencedContainer = "container:FBSnapshotTestCase.xcodeproj">
             </BuildableReference>
@@ -43,7 +43,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "827137791C63AB6F00354E42"
-            BuildableName = "FBSnapshotTestCase tvOS.framework"
+            BuildableName = "FBSnapshotTestCase.framework"
             BlueprintName = "FBSnapshotTestCase tvOS"
             ReferencedContainer = "container:FBSnapshotTestCase.xcodeproj">
          </BuildableReference>
@@ -65,7 +65,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "827137791C63AB6F00354E42"
-            BuildableName = "FBSnapshotTestCase tvOS.framework"
+            BuildableName = "FBSnapshotTestCase.framework"
             BlueprintName = "FBSnapshotTestCase tvOS"
             ReferencedContainer = "container:FBSnapshotTestCase.xcodeproj">
          </BuildableReference>
@@ -83,7 +83,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "827137791C63AB6F00354E42"
-            BuildableName = "FBSnapshotTestCase tvOS.framework"
+            BuildableName = "FBSnapshotTestCase.framework"
             BlueprintName = "FBSnapshotTestCase tvOS"
             ReferencedContainer = "container:FBSnapshotTestCase.xcodeproj">
          </BuildableReference>

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -eu
 function ci_lib() {
     NAME=$1
     xcodebuild -project FBSnapshotTestCase.xcodeproj \
-               -scheme FBSnapshotTestCase \
+               -scheme "FBSnapshotTestCase iOS" \
                -destination "platform=iOS Simulator,name=${NAME}" \
                -sdk iphonesimulator \
                build test


### PR DESCRIPTION
I needed support for this library in an Apple TV project so I added a target and configured everything so it can work. I didn't know though that this has XCTest as a dependency which does not support bitcode which is required on tvOS. So basically the added support for tvOS is broken, but it is there and in case the issue with XCTest is solved sometime this will become handy for tvOS projects as well.

Anybody any ideas how to fix the issue?