### PR TITLE
Compare and record new at the same time

### DIFF
--- a/FBSnapshotTestCase/FBSnapshotTestCase.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.h
@@ -124,6 +124,11 @@
 @interface FBSnapshotTestCase : XCTestCase
 
 /**
+ Test mode. Can be record, compare or both combined.
+ */
+@property (readwrite, nonatomic, assign) FBSnapshotTestMode mode;
+
+/**
  When YES, the test macros will save reference images, rather than performing an actual test.
  */
 @property (readwrite, nonatomic, assign) BOOL recordMode;

--- a/FBSnapshotTestCase/FBSnapshotTestCase.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.m
@@ -32,13 +32,21 @@
 
 - (BOOL)recordMode
 {
-  return _snapshotController.recordMode;
+  return _snapshotController.mode & FBSnapshotModeRecord;
 }
 
 - (void)setRecordMode:(BOOL)recordMode
 {
+  _snapshotController.mode = recordMode ? FBSnapshotModeRecord : FBSnapshotModeCompare;
+}
+
+- (FBSnapshotTestMode)mode{
+  return _snapshotController.mode;
+}
+
+- (void)setMode:(FBSnapshotTestMode)mode{
   NSAssert1(_snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
-  _snapshotController.recordMode = recordMode;
+  _snapshotController.mode = mode;
 }
 
 - (BOOL)isDeviceAgnostic

--- a/FBSnapshotTestCase/FBSnapshotTestController.h
+++ b/FBSnapshotTestCase/FBSnapshotTestController.h
@@ -18,6 +18,13 @@ typedef NS_ENUM(NSInteger, FBSnapshotTestControllerErrorCode) {
   FBSnapshotTestControllerErrorCodeImagesDifferentSizes,
   FBSnapshotTestControllerErrorCodeImagesDifferent,
 };
+
+typedef NS_OPTIONS(NSUInteger, FBSnapshotTestMode){
+  FBSnapshotModeNone = 0,
+  FBSnapshotModeCompare = 1 << 0,
+  FBSnapshotModeRecord = 1 << 1
+};
+
 /**
  Errors returned by the methods of FBSnapshotTestController use this domain.
  */
@@ -36,9 +43,9 @@ extern NSString *const FBReferenceImageFilePathKey;
 @interface FBSnapshotTestController : NSObject
 
 /**
- Record snapshots.
+ Record, Compare or both
  */
-@property (readwrite, nonatomic, assign) BOOL recordMode;
+@property (readwrite, nonatomic, assign) FBSnapshotTestMode mode;
 
 /**
  When @c YES appends the name of the device model and OS to the snapshot file name.

--- a/FBSnapshotTestCase/FBSnapshotTestController.m
+++ b/FBSnapshotTestCase/FBSnapshotTestController.m
@@ -44,6 +44,7 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
   if (self = [super init]) {
     _testName = [testName copy];
     _deviceAgnostic = NO;
+    _mode = FBSnapshotModeCompare;
     
     _fileManager = [[NSFileManager alloc] init];
   }
@@ -89,11 +90,14 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
                            tolerance:(CGFloat)tolerance
                                error:(NSError **)errorPtr
 {
-  if (self.recordMode) {
-    return [self _recordSnapshotOfViewOrLayer:viewOrLayer selector:selector identifier:identifier error:errorPtr];
-  } else {
-    return [self _performPixelComparisonWithViewOrLayer:viewOrLayer selector:selector identifier:identifier tolerance:tolerance error:errorPtr];
+  BOOL result = NO;
+  if (self.mode & FBSnapshotModeCompare) {
+    result = [self _performPixelComparisonWithViewOrLayer:viewOrLayer selector:selector identifier:identifier tolerance:tolerance error:errorPtr];
   }
+  if (self.mode & FBSnapshotModeRecord) {
+    result = [self _recordSnapshotOfViewOrLayer:viewOrLayer selector:selector identifier:identifier error:errorPtr];
+  }
+  return result;
 }
 
 - (UIImage *)referenceImageForSelector:(SEL)selector


### PR DESCRIPTION
Added ability to perform both record new image and compare with old one at the same time.

When i am reported about some diff in snapshots by the build server, sometimes i know that there was a small change in color, font or image asset. In this case i only want to regenerate my ref images. But during regeneration i really want to know that no other minor changes was made between test run on a build server and generation. It would be good to generate diffs of old ref images with a potential new one. 