### PR TITLE
Don't throw an exception if view == window

### DIFF
--- a/FBSnapshotTestCase/Categories/UIImage+Snapshot.m
+++ b/FBSnapshotTestCase/Categories/UIImage+Snapshot.m
@@ -51,7 +51,7 @@
     window = [[UIApplication sharedApplication] fb_strictKeyWindow];
   }
 
-  if (!view.window) {
+  if (!view.window && view != window) {
     [window addSubview:view];
     removeFromSuperview = YES;
   }


### PR DESCRIPTION
This happens when snapshotting the key window.
This was introduced by #137.