### PR TITLE
Add ability to exclude OS version from snapshot file name

### DIFF
--- a/FBSnapshotTestCase/FBSnapshotTestCase.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.h
@@ -131,8 +131,20 @@
 /**
  When @c YES appends the name of the device model and OS to the snapshot file name.
  The default value is @c NO.
+
+ @see includeOSVersionInFilename
  */
 @property (readwrite, nonatomic, assign, getter=isDeviceAgnostic) BOOL deviceAgnostic;
+
+/**
+ Used in conjunction with @c deviceAgnostic, when @c YES the OS version will be included in the snapshot file name.
+ The default value is @c YES.
+
+ @attention @c deviceAgnostic needs to be set to @c YES for this to take effect
+
+ @see deviceAgnostic
+ */
+@property (readwrite, nonatomic, assign) BOOL includeOSVersionInFilename;
 
 /**
  When YES, renders a snapshot of the complete view hierarchy as visible onscreen.

--- a/FBSnapshotTestCase/FBSnapshotTestCase.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.m
@@ -52,6 +52,17 @@
   _snapshotController.deviceAgnostic = deviceAgnostic;
 }
 
+- (BOOL)includeOSVersionInFilename
+{
+  return _snapshotController.includeOSVersionInFilename;
+}
+
+- (void)setIncludeOSVersionInFilename:(BOOL)include
+{
+  NSAssert1(_snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
+  _snapshotController.includeOSVersionInFilename = include;
+}
+
 - (BOOL)usesDrawViewHierarchyInRect
 {
   return _snapshotController.usesDrawViewHierarchyInRect;

--- a/FBSnapshotTestCase/FBSnapshotTestCasePlatform.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCasePlatform.h
@@ -37,7 +37,7 @@ NSOrderedSet *FBSnapshotTestCaseDefaultSuffixes(void);
  
  @returns An @c NSString object containing the passed @c fileName with the device model, OS and screen size appended at the end.
  */
-NSString *FBDeviceAgnosticNormalizedFileName(NSString *fileName);
+NSString *FBDeviceAgnosticNormalizedFileName(NSString *fileName, BOOL includeOSVersion);
 
 #ifdef __cplusplus
 }

--- a/FBSnapshotTestCase/FBSnapshotTestCasePlatform.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCasePlatform.m
@@ -32,20 +32,25 @@ NSOrderedSet *FBSnapshotTestCaseDefaultSuffixes(void)
   return [suffixesSet copy];
 }
 
-NSString *FBDeviceAgnosticNormalizedFileName(NSString *fileName)
+NSString *FBDeviceAgnosticNormalizedFileName(NSString *fileName, BOOL includeOSVersion)
 {
+  NSMutableString *deviceAgnosticFilename = [fileName mutableCopy];
+
   UIDevice *device = [UIDevice currentDevice];
+  [deviceAgnosticFilename appendFormat:@"_%@", device.model];
+
+  if (includeOSVersion) {
+    [deviceAgnosticFilename appendFormat:@"%@", device.systemVersion];
+  }
+
   UIWindow *keyWindow = [[UIApplication sharedApplication] fb_strictKeyWindow];
   CGSize screenSize = keyWindow.bounds.size;
-  NSString *os = device.systemVersion;
-  
-  fileName = [NSString stringWithFormat:@"%@_%@%@_%.0fx%.0f", fileName, device.model, os, screenSize.width, screenSize.height];
-  
+  [deviceAgnosticFilename appendFormat:@"_%.0fx%.0f", screenSize.width, screenSize.height];
+
   NSMutableCharacterSet *invalidCharacters = [NSMutableCharacterSet new];
   [invalidCharacters formUnionWithCharacterSet:[NSCharacterSet whitespaceCharacterSet]];
   [invalidCharacters formUnionWithCharacterSet:[NSCharacterSet punctuationCharacterSet]];
-  NSArray *validComponents = [fileName componentsSeparatedByCharactersInSet:invalidCharacters];
-  fileName = [validComponents componentsJoinedByString:@"_"];
-  
-  return fileName;
+  NSArray *validComponents = [deviceAgnosticFilename componentsSeparatedByCharactersInSet:invalidCharacters];
+
+  return [validComponents componentsJoinedByString:@"_"];
 }

--- a/FBSnapshotTestCase/FBSnapshotTestController.h
+++ b/FBSnapshotTestCase/FBSnapshotTestController.h
@@ -58,8 +58,20 @@ extern NSString *const FBDiffedImageKey;
 /**
  When @c YES appends the name of the device model and OS to the snapshot file name.
  The default value is @c NO.
+
+ @see includeOSVersionInFilename
  */
 @property (readwrite, nonatomic, assign, getter=isDeviceAgnostic) BOOL deviceAgnostic;
+
+/**
+ Used in conjunction with @c deviceAgnostic, when @c YES the OS version will be included in the snapshot file name.
+ The default value is @c YES.
+
+ @attention @c deviceAgnostic needs to be set to @c YES for this to take effect
+
+ @see deviceAgnostic
+ */
+@property (readwrite, nonatomic, assign) BOOL includeOSVersionInFilename;
 
 /**
  Uses drawViewHierarchyInRect:afterScreenUpdates: to draw the image instead of renderInContext:

--- a/FBSnapshotTestCase/FBSnapshotTestController.m
+++ b/FBSnapshotTestCase/FBSnapshotTestController.m
@@ -47,6 +47,7 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
   if (self = [super init]) {
     _testName = [testName copy];
     _deviceAgnostic = NO;
+    _includeOSVersionInFilename = YES;
     
     _fileManager = [[NSFileManager alloc] init];
   }
@@ -234,7 +235,7 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
   }
   
   if (self.isDeviceAgnostic) {
-    fileName = FBDeviceAgnosticNormalizedFileName(fileName);
+    fileName = FBDeviceAgnosticNormalizedFileName(fileName, self.includeOSVersionInFilename);
   }
   
   if ([[UIScreen mainScreen] scale] > 1) {

--- a/FBSnapshotTestCaseTests/FBSnapshotControllerTests.m
+++ b/FBSnapshotTestCaseTests/FBSnapshotControllerTests.m
@@ -105,8 +105,23 @@
   SEL selector = @selector(isDeviceAgnostic);
   [controller referenceImageForSelector:selector identifier:@"" error:&error];
   XCTAssertNotNil(error);
-  NSString *deviceAgnosticReferencePath = FBDeviceAgnosticNormalizedFileName(NSStringFromSelector(selector));
+  NSString *deviceAgnosticReferencePath = FBDeviceAgnosticNormalizedFileName(NSStringFromSelector(selector), true);
   XCTAssertTrue([(NSString *)[error.userInfo objectForKey:FBReferenceImageFilePathKey] containsString:deviceAgnosticReferencePath]);
+}
+
+- (void)testFilenameDoesNotContainOSVersionWhenIncludeOSInFilenameIsFalse
+{
+  FBSnapshotTestController *controller = [[FBSnapshotTestController alloc] initWithTestClass:nil];
+  [controller setDeviceAgnostic:YES];
+  [controller setIncludeOSVersionInFilename:NO];
+
+  [controller setReferenceImagesDirectory:@"/dev/null/"];
+  NSError *error = nil;
+  SEL selector = @selector(includeOSVersionInFilename);
+  [controller referenceImageForSelector:selector identifier:@"" error:&error];
+  XCTAssertNotNil(error);
+  NSString *includeOSVersionInFilenameReferencePath = FBDeviceAgnosticNormalizedFileName(NSStringFromSelector(selector), false);
+  XCTAssertTrue([(NSString *)[error.userInfo objectForKey:FBReferenceImageFilePathKey] containsString:includeOSVersionInFilenameReferencePath]);
 }
 
 #pragma mark - Private helper methods


### PR DESCRIPTION
We run tests on multiple devices and use `deviceAgnostic` to get images specific for each device. We only ever test on the latest OS, and the current behaviour is that the OS version is included in the filename.

This presents a number of problems when we are updating tests to the latest OS. Namely, we end up with completely different images so we can't compare changes easily, and we also end up with orphaned images that we must remember to manually delete.

This PR adds a Boolean, `includeOSVersionInFilename` to FBSnapshotTestCase to control whether the version gets included in the filename when using `deviceAgnostic = true`. By default it is set to `YES` so that it doesn't break current users. If it is set to `NO`, you will get a snapshot file name that includes the device model, but not the OS version.