### PR TITLE
Add support for non-standard content/images scales

### DIFF
--- a/FBSnapshotTestCase/Categories/UIImage+Compare.m
+++ b/FBSnapshotTestCase/Categories/UIImage+Compare.m
@@ -46,11 +46,11 @@ typedef union {
 
 - (BOOL)fb_compareWithImage:(UIImage *)image tolerance:(CGFloat)tolerance
 {
-  NSAssert(CGSizeEqualToSize(self.size, image.size), @"Images must be same size.");
-  
   CGSize referenceImageSize = CGSizeMake(CGImageGetWidth(self.CGImage), CGImageGetHeight(self.CGImage));
   CGSize imageSize = CGSizeMake(CGImageGetWidth(image.CGImage), CGImageGetHeight(image.CGImage));
-    
+
+  NSAssert(CGSizeEqualToSize(referenceImageSize, imageSize), @"Images must be same size.");
+
   // The images have the equal size, so we could use the smallest amount of bytes because of byte padding
   size_t minBytesPerRow = MIN(CGImageGetBytesPerRow(self.CGImage), CGImageGetBytesPerRow(image.CGImage));
   size_t referenceImageSizeBytes = referenceImageSize.height * minBytesPerRow;

--- a/FBSnapshotTestCase/Categories/UIImage+Diff.m
+++ b/FBSnapshotTestCase/Categories/UIImage+Diff.m
@@ -38,7 +38,7 @@
     return nil;
   }
   CGSize imageSize = CGSizeMake(MAX(self.size.width, image.size.width), MAX(self.size.height, image.size.height));
-  UIGraphicsBeginImageContextWithOptions(imageSize, YES, 0);
+  UIGraphicsBeginImageContextWithOptions(imageSize, YES, self.scale);
   CGContextRef context = UIGraphicsGetCurrentContext();
   [self drawInRect:CGRectMake(0, 0, self.size.width, self.size.height)];
   CGContextSetAlpha(context, 0.5);

--- a/FBSnapshotTestCase/Categories/UIImage+Snapshot.h
+++ b/FBSnapshotTestCase/Categories/UIImage+Snapshot.h
@@ -13,12 +13,12 @@
 @interface UIImage (Snapshot)
 
 /// Uses renderInContext: to get a snapshot of the layer.
-+ (UIImage *)fb_imageForLayer:(CALayer *)layer;
++ (UIImage *)fb_imageForLayer:(CALayer *)layer scale:(CGFloat)scale;
 
 /// Uses renderInContext: to get a snapshot of the view layer.
-+ (UIImage *)fb_imageForViewLayer:(UIView *)view;
++ (UIImage *)fb_imageForViewLayer:(UIView *)view scale:(CGFloat)scale;
 
 /// Uses drawViewHierarchyInRect: to get a snapshot of the view and adds the view into a window if needed.
-+ (UIImage *)fb_imageForView:(UIView *)view;
++ (UIImage *)fb_imageForView:(UIView *)view scale:(CGFloat)scale;
 
 @end

--- a/FBSnapshotTestCase/Categories/UIImage+Snapshot.m
+++ b/FBSnapshotTestCase/Categories/UIImage+Snapshot.m
@@ -13,13 +13,13 @@
 
 @implementation UIImage (Snapshot)
 
-+ (UIImage *)fb_imageForLayer:(CALayer *)layer
++ (UIImage *)fb_imageForLayer:(CALayer *)layer scale:(CGFloat)scale
 {
   CGRect bounds = layer.bounds;
   NSAssert1(CGRectGetWidth(bounds), @"Zero width for layer %@", layer);
   NSAssert1(CGRectGetHeight(bounds), @"Zero height for layer %@", layer);
 
-  UIGraphicsBeginImageContextWithOptions(bounds.size, NO, 0);
+  UIGraphicsBeginImageContextWithOptions(bounds.size, NO, scale);
   CGContextRef context = UIGraphicsGetCurrentContext();
   NSAssert1(context, @"Could not generate context for layer %@", layer);
   CGContextSaveGState(context);
@@ -32,13 +32,13 @@
   return snapshot;
 }
 
-+ (UIImage *)fb_imageForViewLayer:(UIView *)view
++ (UIImage *)fb_imageForViewLayer:(UIView *)view scale:(CGFloat)scale
 {
   [view layoutIfNeeded];
-  return [self fb_imageForLayer:view.layer];
+  return [self fb_imageForLayer:view.layer scale:scale];
 }
 
-+ (UIImage *)fb_imageForView:(UIView *)view
++ (UIImage *)fb_imageForView:(UIView *)view scale:(CGFloat)scale
 {
   CGRect bounds = view.bounds;
   NSAssert1(CGRectGetWidth(bounds), @"Zero width for view %@", view);
@@ -56,7 +56,7 @@
     removeFromSuperview = YES;
   }
 
-  UIGraphicsBeginImageContextWithOptions(bounds.size, NO, 0);
+  UIGraphicsBeginImageContextWithOptions(bounds.size, NO, scale);
   [view layoutIfNeeded];
   [view drawViewHierarchyInRect:view.bounds afterScreenUpdates:YES];
 

--- a/FBSnapshotTestCase/FBSnapshotTestCase.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.h
@@ -145,6 +145,11 @@
  */
 @property (readwrite, nonatomic, assign) BOOL usesDrawViewHierarchyInRect;
 
+/**
+ When set to values different than 0, it uses a specific scale for generating and comparing images rather than using the main screen's default scale.
+ */
+@property (readwrite, nonatomic, assign) NSUInteger manualScale;
+
 - (void)setUp NS_REQUIRES_SUPER;
 - (void)tearDown NS_REQUIRES_SUPER;
 

--- a/FBSnapshotTestCase/FBSnapshotTestCase.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.m
@@ -63,6 +63,17 @@
   _snapshotController.usesDrawViewHierarchyInRect = usesDrawViewHierarchyInRect;
 }
 
+- (void)setManualScale:(NSUInteger)manualScale
+{
+  NSAssert1(_snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
+  _snapshotController.manualScale = manualScale;
+}
+
+- (NSUInteger)manualScale
+{
+  return _snapshotController.manualScale;
+}
+
 #pragma mark - Public API
 
 - (BOOL)compareSnapshotOfLayer:(CALayer *)layer
@@ -115,7 +126,6 @@
   }
   return [[NSBundle bundleForClass:self.class].resourcePath stringByAppendingPathComponent:@"ReferenceImages"];
 }
-
 
 #pragma mark - Private API
 

--- a/FBSnapshotTestCase/FBSnapshotTestController.h
+++ b/FBSnapshotTestCase/FBSnapshotTestController.h
@@ -72,6 +72,11 @@ extern NSString *const FBDiffedImageKey;
 @property (readwrite, nonatomic, copy) NSString *referenceImagesDirectory;
 
 /**
+ When set to values different than 0, it uses a specific scale for generating and comparing images rather than using the main screen's default scale.
+ */
+@property (readwrite, nonatomic, assign) NSUInteger manualScale;
+
+/**
  @param testClass The subclass of FBSnapshotTestCase that is using this controller.
  @returns An instance of FBSnapshotTestController.
  */


### PR DESCRIPTION
Currently the framework uses [[UIScreen mainScreen] scale] for saving and comparing snapshots of views and layers.

If the view or layer are meant to be displayed at a different scale that doesn't match the main screen's one, the screenshots get resized (minified / magnified) and the comparisons are not correct any more from the point of view of the user, since the images are different from what will be shown to the user.

This PR tries to remove this limitation for those special cases by allowing the test developer to manually override the scale that will be used.