### PR TITLE
Bump version to 2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.1.2
+
+  - Disabled Bitcode for tvOS target (#169)
+  - Added user target in podspec (#165)
+
 ## 2.1.1
 
   - Added tvOS support for cocoapods (#163)

--- a/FBSnapshotTestCase.podspec
+++ b/FBSnapshotTestCase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "FBSnapshotTestCase"
-  s.version      = "2.1.1"
+  s.version      = "2.1.2"
   s.summary      = "Snapshot view unit tests for iOS"
   s.description  = <<-DESC
                     A "snapshot test case" takes a configured UIView or CALayer

--- a/FBSnapshotTestCaseDemo/Podfile.lock
+++ b/FBSnapshotTestCaseDemo/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - FBSnapshotTestCase (2.1.1):
-    - FBSnapshotTestCase/SwiftSupport (= 2.1.1)
-  - FBSnapshotTestCase/Core (2.1.1)
-  - FBSnapshotTestCase/SwiftSupport (2.1.1):
+  - FBSnapshotTestCase (2.1.2):
+    - FBSnapshotTestCase/SwiftSupport (= 2.1.2)
+  - FBSnapshotTestCase/Core (2.1.2)
+  - FBSnapshotTestCase/SwiftSupport (2.1.2):
     - FBSnapshotTestCase/Core
 
 DEPENDENCIES:
@@ -10,10 +10,10 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   FBSnapshotTestCase:
-    :path: ..
+    :path: ".."
 
 SPEC CHECKSUMS:
-  FBSnapshotTestCase: 432afd8d059ccef7f207225894840a03fbcf7474
+  FBSnapshotTestCase: 918c55861356ee83aee7843d759f55a18ff6982b
 
 PODFILE CHECKSUM: f0c8c3073f8e31e4718d87d66744e7fa5953f5c4
 


### PR DESCRIPTION
- Disabled Bitcode for tvOS target (#169)
- Added user target in podspec (#165)
