### PR TITLE
Bump version to 2.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.1.4
+
+  - Swift 3 suppport (#194)
+  - Replace big macro with Objective-C method for easier debugging (#180)
+
 ## 2.1.3
 
   - Allow to compile with Xcode 7 and Xcode 8 Swift 2.3 (#179)

--- a/FBSnapshotTestCase.podspec
+++ b/FBSnapshotTestCase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "FBSnapshotTestCase"
-  s.version      = "2.1.3"
+  s.version      = "2.1.4"
   s.summary      = "Snapshot view unit tests for iOS"
   s.description  = <<-DESC
                     A "snapshot test case" takes a configured UIView or CALayer
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.author       = 'Facebook'
   s.source       = { :git => "https://github.com/facebook/ios-snapshot-test-case.git",
                      :tag => s.version.to_s }
-  s.ios.deployment_target  = '8.0'
+  s.ios.deployment_target  = '7.0'
   s.tvos.deployment_target = '9.0'
   s.requires_arc = true
   s.frameworks   = 'XCTest','UIKit','Foundation','QuartzCore'


### PR DESCRIPTION
# 2.1.4

- Swift 3 suppport (#194)
- Replace big macro with Objective-C method for easier debugging (#180)
- Support iOS7 (#198)