### PR TITLE
Fix broken FB_REFERENCE_IMAGE_DIR preprocessor macro

### DIFF
--- a/FBSnapshotTestCase/FBSnapshotTestCase.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.h
@@ -62,7 +62,7 @@
 
 #define FBSnapshotVerifyViewOrLayerWithOptions(what__, viewOrLayer__, identifier__, suffixes__, tolerance__) \
 { \
-  NSString *errorDescription = [self snapshotVerifyViewOrLayer:viewOrLayer__ identifier:identifier__ suffixes:suffixes__ tolerance:tolerance__]; \
+  NSString *errorDescription = [self snapshotVerifyViewOrLayer:viewOrLayer__ identifier:identifier__ suffixes:suffixes__ tolerance:tolerance__ defaultReferenceDirectory:(@ FB_REFERENCE_IMAGE_DIR)]; \
   BOOL noErrors = (errorDescription == nil); \
   XCTAssertTrue(noErrors, @"%@", errorDescription); \
 }
@@ -120,12 +120,14 @@
  @param identifier An optional identifier, used if there are multiple snapshot tests in a given -test method.
  @param suffixes An NSOrderedSet of strings for the different suffixes
  @param tolerance The percentage difference to still count as identical - 0 mean pixel perfect, 1 means I don't care
+ @param defaultReferenceDirectory The directory to default to for reference images.
  @returns nil if the comparison (or saving of the reference image) succeeded. Otherwise it contains an error description.
  */
 - (NSString *)snapshotVerifyViewOrLayer:(id)viewOrLayer
                              identifier:(NSString *)identifier
                                suffixes:(NSOrderedSet *)suffixes
-                              tolerance:(CGFloat)tolerance;
+                              tolerance:(CGFloat)tolerance
+              defaultReferenceDirectory:(NSString *)defaultReferenceDirectory;
 
 /**
  Performs the comparison or records a snapshot of the layer if recordMode is YES.

--- a/FBSnapshotTestCase/FBSnapshotTestCase.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.m
@@ -69,11 +69,12 @@
                              identifier:(NSString *)identifier
                                suffixes:(NSOrderedSet *)suffixes
                               tolerance:(CGFloat)tolerance
+              defaultReferenceDirectory:(NSString *)defaultReferenceDirectory
 {
   if (nil == viewOrLayer) {
     return @"Object to be snapshotted must not be nil";
   }
-  NSString *referenceImageDirectory = [self getReferenceImageDirectoryWithDefault:(@ FB_REFERENCE_IMAGE_DIR)];
+  NSString *referenceImageDirectory = [self getReferenceImageDirectoryWithDefault:defaultReferenceDirectory];
   if (referenceImageDirectory == nil) {
     return @"Missing value for referenceImagesDirectory - Set FB_REFERENCE_IMAGE_DIR as Environment variable in your scheme.";
   }


### PR DESCRIPTION
[A change](https://github.com/facebook/ios-snapshot-test-case/commit/6a3f71fd69b7fab9d7aced48100199c104ac1719) was made that converted the bulk of what was previously a macro, to actual code. The problem with that, was it moved the tricky use of FB_REFERENCE_IMAGE_DIR out of the macro, so setting `FB_REFERENCE_IMAGE_DIR` in your preprocessor macros yourself no longer worked.

It used to work by replacing instances of `FB_REFERENCE_IMAGE_DIR` in the preprocessor step with the one you could set in your preprocessor macros, but that doesn't seem to work unless you're in a #define.

Fixes #209 