### PR TITLE
Add a property to set the image diff directory

### DIFF
--- a/FBSnapshotTestCase/FBSnapshotTestController.h
+++ b/FBSnapshotTestCase/FBSnapshotTestController.h
@@ -67,9 +67,14 @@ extern NSString *const FBDiffedImageKey;
 @property (readwrite, nonatomic, assign) BOOL usesDrawViewHierarchyInRect;
 
 /**
- The directory in which referfence images are stored.
+ The directory in which reference images are stored.
  */
 @property (readwrite, nonatomic, copy) NSString *referenceImagesDirectory;
+
+/**
+ The directory in which failed snapshot images are stored.
+ */
+@property (readwrite, nonatomic, copy) NSString *imageDiffDirectory;
 
 /**
  @param testClass The subclass of FBSnapshotTestCase that is using this controller.

--- a/FBSnapshotTestCase/FBSnapshotTestController.m
+++ b/FBSnapshotTestCase/FBSnapshotTestController.m
@@ -259,6 +259,8 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
                               identifier:(NSString *)identifier
                             fileNameType:(FBTestSnapshotFileNameType)fileNameType
 {
+  NSAssert(getenv("IMAGE_DIFF_DIR") && _imageDiffDirectory.length, @"Image diff directory set in both environment variable and property");
+  
   NSString *fileName = [self _fileNameForSelector:selector
                                        identifier:identifier
                                      fileNameType:fileNameType];

--- a/FBSnapshotTestCase/FBSnapshotTestController.m
+++ b/FBSnapshotTestCase/FBSnapshotTestController.m
@@ -265,6 +265,8 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
   NSString *folderPath = NSTemporaryDirectory();
   if (getenv("IMAGE_DIFF_DIR")) {
     folderPath = @(getenv("IMAGE_DIFF_DIR"));
+  } else if ([_imageDiffDirectory length] > 0) {
+    folderPath = _imageDiffDirectory;
   }
   NSString *filePath = [folderPath stringByAppendingPathComponent:_testName];
   filePath = [filePath stringByAppendingPathComponent:fileName];

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Installation with CocoaPods
 |`FB_REFERENCE_IMAGE_DIR`|`$(SOURCE_ROOT)/$(PROJECT_NAME)Tests/ReferenceImages`|
 |`IMAGE_DIFF_DIR`|`$(SOURCE_ROOT)/$(PROJECT_NAME)Tests/FailureDiffs`|
 
-Define the `IMAGE_DIFF_DIR` to the directory where you want to store diffs of failed snapshots.
+Define the `IMAGE_DIFF_DIR` to the directory where you want to store diffs of failed snapshots. There is [an alternate way](https://github.com/facebook/ios-snapshot-test-case/blob/master/FBSnapshotTestCase/FBSnapshotTestController.h#L74-L77) to set the failed snapshots directory using a property on the test controller.
 
 ![](FBSnapshotTestCaseDemo/Scheme_FB_REFERENCE_IMAGE_DIR.png)
 


### PR DESCRIPTION
It is possible to set the reference images directory using both an environment variable (`FB_REFERENCE_IMAGE_DIR`) and a property (`referenceImagesDirectory`), but the same flexibility isn't afforded to the image diff directory, which is only settable using an environment variable (`IMAGE_DIFF_DIR`). This pull request also adds a property (`imageDiffDirectory`) for the image diff directory location.