### PR TITLE
Updates README.md to show the use of use_frameworks!

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Installation with CocoaPods
 
      ```
      target "Tests" do
+       use_frameworks!
        pod 'FBSnapshotTestCase'
      end
      ```


### PR DESCRIPTION
Since `SwiftSupport.swift` was added to the source of this framework, Cocoapods installation breaks with the following error "Pods written in Swift can only be integrated as frameworks". The use of `use_frameworks!` is now obligatory.