### PR TITLE
Use 'String(describing:)' to silence compiler warning

### DIFF
--- a/FBSnapshotTestCase/SwiftSupport.swift
+++ b/FBSnapshotTestCase/SwiftSupport.swift
@@ -52,7 +52,7 @@
             break
           }
 
-          assert(comparisonSuccess, message: "Snapshot comparison failed: \(error)", file: file, line: line)
+          assert(comparisonSuccess, message: "Snapshot comparison failed: \(String(describing: error))", file: file, line: line)
         }
       } else {
         XCTFail("Missing value for referenceImagesDirectory - Set FB_REFERENCE_IMAGE_DIR as Environment variable in your scheme.")


### PR DESCRIPTION
Silence warning "String interpolation produces a debug description for an optional value"

Relates to issue [221](https://github.com/facebook/ios-snapshot-test-case/issues/221)