### PR TITLE
Implement Xcode 9 integration using XCTAttachment API

### DIFF
--- a/FBSnapshotTestCase/FBSnapshotTestCase.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.m
@@ -10,6 +10,7 @@
 
 #import <FBSnapshotTestCase/FBSnapshotTestCase.h>
 #import <FBSnapshotTestCase/FBSnapshotTestController.h>
+#import <Availability.h>
 
 @implementation FBSnapshotTestCase
 {
@@ -111,15 +112,50 @@
       }
     }
   }
-  
-  if (!testSuccess) {
-    return [NSString stringWithFormat:@"Snapshot comparison failed: %@", errors.firstObject];
-  }
+    
+  [self addAttachementsWithErrors:errors identifier:identifier];
+    
   if (self.recordMode) {
-    return @"Test ran in record mode. Reference image is now saved. Disable record mode to perform an actual snapshot comparison!";
+    if (errors.count > 0) {
+      return [NSString stringWithFormat:@"Snapshot comparison failed: %@", errors.firstObject];
+    } else {
+      return @"Test ran in record mode. Reference image is now saved. Disable record mode to perform an actual snapshot comparison!";
+    }
+  } else if (!testSuccess) {
+    return [NSString stringWithFormat:@"Snapshot comparison failed: %@", errors.firstObject];
   }
 
   return nil;
+}
+
+- (void) addAttachementsWithErrors:(NSArray<NSError*>*)errors identifier:(NSString*)identifier {
+#ifdef __IPHONE_11_0
+    if (self.recordMode) {
+        UIImage* image = [_snapshotController referenceImageForSelector:self.invocation.selector identifier:identifier error:nil];
+        if (image) {
+            XCTAttachment* attachement = [XCTAttachment attachmentWithImage:image];
+            attachement.name = @"Reference Image";
+            [self addAttachment:attachement];
+        }
+    } else if (errors.firstObject != nil) {
+        NSError* error = errors.firstObject;
+        if (error.userInfo[FBReferenceImageKey] != nil) {
+            XCTAttachment* attachement = [XCTAttachment attachmentWithImage:error.userInfo[FBReferenceImageKey]];
+            attachement.name = @"Reference Image";
+            [self addAttachment:attachement];
+        }
+        if (error.userInfo[FBCapturedImageKey] != nil) {
+            XCTAttachment* attachement = [XCTAttachment attachmentWithImage:error.userInfo[FBCapturedImageKey]];
+            attachement.name = @"Captured Image";
+            [self addAttachment:attachement];
+        }
+        if (error.userInfo[FBDiffedImageKey] != nil) {
+            XCTAttachment* attachement = [XCTAttachment attachmentWithImage:error.userInfo[FBDiffedImageKey]];
+            attachement.name = @"Diffed Image";
+            [self addAttachment:attachement];
+        }
+    }
+#endif
 }
 
 - (BOOL)compareSnapshotOfLayer:(CALayer *)layer

--- a/FBSnapshotTestCase/SwiftSupport.swift
+++ b/FBSnapshotTestCase/SwiftSupport.swift
@@ -11,58 +11,15 @@
 #if swift(>=3)
   public extension FBSnapshotTestCase {
     public func FBSnapshotVerifyView(_ view: UIView, identifier: String = "", suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), tolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {
-      FBSnapshotVerifyViewOrLayer(view, identifier: identifier, suffixes: suffixes, tolerance: tolerance, file: file, line: line)
+        if let errorDescription = snapshotVerifyViewOrLayer(view, identifier: identifier, suffixes: suffixes, tolerance: tolerance, defaultReferenceDirectory: FB_REFERENCE_IMAGE_DIR) {
+            XCTFail(errorDescription, file: file, line: line)
+        }
     }
 
     public func FBSnapshotVerifyLayer(_ layer: CALayer, identifier: String = "", suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), tolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {
-      FBSnapshotVerifyViewOrLayer(layer, identifier: identifier, suffixes: suffixes, tolerance: tolerance, file: file, line: line)
-    }
-
-    private func FBSnapshotVerifyViewOrLayer(_ viewOrLayer: AnyObject, identifier: String = "", suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), tolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {
-      let envReferenceImageDirectory = self.getReferenceImageDirectory(withDefault: FB_REFERENCE_IMAGE_DIR)
-      var error: NSError?
-      var comparisonSuccess = false
-
-      if let envReferenceImageDirectory = envReferenceImageDirectory {
-        for suffix in suffixes {
-          let referenceImagesDirectory = "\(envReferenceImageDirectory)\(suffix)"
-          if viewOrLayer.isKind(of: UIView.self) {
-            do {
-              try compareSnapshot(of: viewOrLayer as! UIView, referenceImagesDirectory: referenceImagesDirectory, identifier: identifier, tolerance: tolerance)
-              comparisonSuccess = true
-            } catch let error1 as NSError {
-              error = error1
-              comparisonSuccess = false
-            }
-          } else if viewOrLayer.isKind(of: CALayer.self) {
-            do {
-              try compareSnapshot(of: viewOrLayer as! CALayer, referenceImagesDirectory: referenceImagesDirectory, identifier: identifier, tolerance: tolerance)
-              comparisonSuccess = true
-            } catch let error1 as NSError {
-              error = error1
-              comparisonSuccess = false
-            }
-          } else {
-            assertionFailure("Only UIView and CALayer classes can be snapshotted")
-          }
-
-          assert(recordMode == false, message: "Test ran in record mode. Reference image is now saved. Disable record mode to perform an actual snapshot comparison!", file: file, line: line)
-
-          if comparisonSuccess || recordMode {
-            break
-          }
-
-          assert(comparisonSuccess, message: "Snapshot comparison failed: \(error)", file: file, line: line)
+        if let errorDescription = snapshotVerifyViewOrLayer(layer, identifier: identifier, suffixes: suffixes, tolerance: tolerance, defaultReferenceDirectory: FB_REFERENCE_IMAGE_DIR) {
+            XCTFail(errorDescription, file: file, line: line)
         }
-      } else {
-        XCTFail("Missing value for referenceImagesDirectory - Set FB_REFERENCE_IMAGE_DIR as Environment variable in your scheme.")
-      }
-    }
-
-    func assert(_ assertion: Bool, message: String, file: StaticString, line: UInt) {
-      if !assertion {
-        XCTFail(message, file: file, line: line)
-      }
     }
   }
 #else


### PR DESCRIPTION
XCTest in Xcode 9 has a great new feature called [attachments](https://developer.apple.com/documentation/xctest/xctattachment). It allows to add attachments to test results. So we can add our captured, reference and diff images to test if it was failed(see example on screenshot). 
<img width="1553" alt="screen shot 2017-06-13 at 13 00 54" src="https://user-images.githubusercontent.com/266271/27077371-8c59c740-5038-11e7-80e7-f78690b95533.png">
